### PR TITLE
Multi arch build

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -4,13 +4,7 @@ steps:
     # Only run triggered by the Kolibri pipeline and it's not a release
     if: build.env("LE_KOLIBRI_RELEASE") == "false" || build.env("LE_TRIGGERED_FROM_KOLIBRI_VERSION_TAG") == ""
 
-  - label: "Build Android APK (32bit) :tada:"
+  - label: "Build Android APK :tada:"
     command: ".buildkite/build.sh"
     env:
       KOLIBRI_ANDROID_BUILD_MODE: "release"
-
-  - label: "Build Android APK (64bit) :tada:"
-    command: ".buildkite/build.sh"
-    env:
-      KOLIBRI_ANDROID_BUILD_MODE: "release"
-      ARCH: "64bit"

--- a/.github/workflows/build_apk.yml
+++ b/.github/workflows/build_apk.yml
@@ -7,21 +7,9 @@ on:
       whl-url:
         description: 'URL for Kolibri whl file'
         required: true
-      arch:
-        description: 'Architecture of the build'
-        required: true
-        default: '32bit'
-        type: choice
-        options:
-          - 32bit
-          - 64bit
   workflow_call:
     inputs:
       whl-file-name:
-        required: true
-        type: string
-      arch:
-        description: 'Architecture of the build: 32bit or 64bit'
         required: true
         type: string
       ref:
@@ -57,9 +45,9 @@ jobs:
         # aggressive in clearing the cache whenever any file changes
         # in the repository.
         path: ~/.local
-        key: ${{ runner.os }}-local-${{ github.event.inputs.arch || inputs.arch }}-${{ hashFiles('*') }}
+        key: ${{ runner.os }}-local-${{ hashFiles('*') }}
         restore-keys: |
-          ${{ runner.os }}-local-${{ github.event.inputs.arch || inputs.arch }}-
+          ${{ runner.os }}-local-
     - uses: actions/cache@v2
       with:
         path: ~/.cache/pip
@@ -79,7 +67,6 @@ jobs:
       run: pip install -r requirements.txt
     - name: Build the app
       env:
-        ARCH: ${{ github.event.inputs.arch || inputs.arch }}
         # No need to set the ANDROID_HOME environment variable here that is used for
         # setting up the ANDROID SDK and ANDROID NDK, as the github actions images
         # have these SDKs and NDKs already installed.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,10 @@ Follow the instructions from the command to set your environment variables.
 
 To download a Kolibri WHL file, you can use `make whl=<URL>` from the command line. It will download it and put it in the correct directory.
 
-5. If you need a 64bit build, set the `ARCH` environment variable to `64bit`.
+5. By default the APK will be built for most architectures supported by
+   Python for Android. To build for a smaller set of architectures, set
+   the `ARCHES` environment variable. Run `p4a archs` to see the
+   available targets.
 
 6. Run `make kolibri.apk.unsigned` to build the apk. Watch for success at the end, or errors, which might indicate missing build dependencies or build errors. If successful, there should be an APK in the `dist/` directory.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 cython
 virtualenv
-git+https://github.com/learningequality/python-for-android@999271bab4450daf21fc4fd7ef2fe915be9cca1b#egg=python-for-android
+git+https://github.com/endlessm/python-for-android@e4467efac5b72c743c6aa830a6b61f0cb0b62ae1#egg=python-for-android

--- a/scripts/rundocker.sh
+++ b/scripts/rundocker.sh
@@ -6,7 +6,7 @@ SCRIPTDIR=$(realpath "$(dirname "$0")")
 SRCDIR=$(dirname "$SCRIPTDIR")
 DOCKER=${DOCKER:-"docker"}
 
-BUILD_CACHE_VOLUME="kolibri-android-cache-$ARCH"
+BUILD_CACHE_VOLUME=kolibri-android-cache
 BUILD_CACHE_PATH=/cache
 BUILD_UID=$(id -u)
 BUILD_GID=$(id -g)
@@ -34,7 +34,7 @@ RUN_OPTS=(
   --env P4A_RELEASE_KEYALIAS
   --env P4A_RELEASE_KEYSTORE_PASSWD
   --env P4A_RELEASE_KEYALIAS_PASSWD
-  --env ARCH
+  --env ARCHES
 )
 
 # If the release signing key has been specified and exists, ensure the

--- a/scripts/version.py
+++ b/scripts/version.py
@@ -74,17 +74,14 @@ def build_number():
     build_base_number = 2008998000
 
     buildkite_build_number = os.getenv("BUILDKITE_BUILD_NUMBER")
-    increment_for_64bit = 1 if os.getenv("ARCH", "") == "64bit" else 0
 
     if buildkite_build_number is not None:
-        build_number = (
-            build_base_number + 2 * int(buildkite_build_number) + increment_for_64bit
-        )
+        build_number = build_base_number + 2 * int(buildkite_build_number)
         return str(build_number)
 
     alt_build_number = (
         int(datetime.now().strftime("%y%m%d%H%M")) - build_base_number
-    ) * 2 + increment_for_64bit
+    ) * 2
     return alt_build_number
 
 


### PR DESCRIPTION
This allows building multiarch APKs and AABs. Multiarch AABs will be needed for publishing to Google Play. The first commit switches to our p4a fork, which now supports multi-arch in the webview bootstrap from endlessm/python-for-android#2.

https://phabricator.endlessm.com/T33415