### PR TITLE
Remove PID_FILE at launch just once

### DIFF
--- a/src/initialization.py
+++ b/src/initialization.py
@@ -36,13 +36,6 @@ os.environ["KOLIBRI_HOME"] = get_home_folder()
 os.environ["KOLIBRI_APK_VERSION_NAME"] = get_version_name()
 os.environ["DJANGO_SETTINGS_MODULE"] = "kolibri_app_settings"
 
-# Ensure that the pidfile is removed on startup
-PID_FILE = os.path.join(get_home_folder(), "server.pid")
-try:
-    os.unlink(PID_FILE)
-except FileNotFoundError:
-    pass
-
 AUTOPROVISION_FILE = os.path.join(script_dir, "automatic_provision.json")
 if os.path.exists(AUTOPROVISION_FILE):
     os.environ["KOLIBRI_AUTOMATIC_PROVISION_FILE"] = AUTOPROVISION_FILE

--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,6 @@
 import importlib
 import logging
+import os
 import time
 
 import initialization  # noqa: F401 keep this first, to ensure we're set up for other imports
@@ -54,6 +55,12 @@ for plugin_name in REQUIRED_PLUGINS:
 
 for plugin_name in OPTIONAL_PLUGINS:
     _enable_kolibri_plugin(plugin_name, optional=True)
+
+# Ensure that the pidfile is removed on startup
+try:
+    os.unlink(PID_FILE)
+except FileNotFoundError:
+    pass
 
 # we need to initialize Kolibri to allow us to access the app key
 initialize()


### PR DESCRIPTION
This patch moves the PID_FILE check from the initialization.py module to
the main.py module to avoid multiple removal.

The initialization module is imported in different modules:
 * server.py
 * remoteshell.py
 * main.py

https://phabricator.endlessm.com/T33370