### PR TITLE
autologin: Fix DevicePermissions creation

### DIFF
--- a/src/middleware.py
+++ b/src/middleware.py
@@ -21,8 +21,12 @@ class AlwaysAuthenticatedMiddleware(MiddlewareMixin):
             user, created = FacilityUser.objects.get_or_create(
                 username=self.username, facility=facility
             )
-            DevicePermissions.objects.create(
-                user=user, is_superuser=False, can_manage_content=True
+            DevicePermissions.objects.update_or_create(
+                user=user,
+                defaults={
+                    "is_superuser": False,
+                    "can_manage_content": True,
+                },
             )
 
             user.backend = settings.AUTHENTICATION_BACKENDS[0]


### PR DESCRIPTION
Accessing from the browser at the same time as the app is opened fails,
this patch changes the `create` with `get_or_create` on the auto login
middleware, so if the DevicePermissions is present in the database it
doesn't try to create it again.

https://phabricator.endlessm.com/T33461