### PR TITLE
Workaround os.listdir and os.access on external storage

### DIFF
--- a/src/initialization.py
+++ b/src/initialization.py
@@ -3,6 +3,7 @@ import os
 import re
 import sys
 
+from android_utils import apply_android_workarounds
 from android_utils import get_activity
 from android_utils import get_home_folder
 from android_utils import get_signature_key_issuing_organization
@@ -12,6 +13,8 @@ from jnius import autoclass
 
 # initialize logging before loading any third-party modules, as they may cause logging to get configured.
 logging.basicConfig(level=logging.DEBUG)
+
+apply_android_workarounds()
 
 script_dir = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(script_dir)


### PR DESCRIPTION
Android 11 appears to have a bug[1] where `os.listdir` and `os.access`
receive `EACCESS` when accessing app private directories on external
storage. Workaround this issue by monkeypatching the methods so they
don't error in this case.

1. https://issuetracker.google.com/issues/232290073

https://phabricator.endlessm.com/T33372