### PR TITLE
patch: Add Requeue RUNNING jobs on startup patch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,7 @@ src/kolibri: clean
 	sed -i 's/if name.endswith(".py"):/if name.endswith(".py") or name.endswith(".pyc"):/g' src/kolibri/dist/django/db/migrations/loader.py
 	# Apply kolibri patches
 	patch -d src/ -p1 < patches/0001-server-Set-STATUS_RUNNING-just-once.patch
+	patch -d src/ -p1 < patches/0001-Requeue-RUNNING-jobs-on-startup.patch
 
 .PHONY: apps-bundle.zip
 apps-bundle.zip:

--- a/patches/0001-Requeue-RUNNING-jobs-on-startup.patch
+++ b/patches/0001-Requeue-RUNNING-jobs-on-startup.patch
@@ -1,0 +1,72 @@
+From 919fa46c9a1815863265a9db0d272f87b5a13f1d Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Daniel=20Garc=C3=ADa=20Moreno?= <dani@danigm.net>
+Date: Mon, 25 Apr 2022 12:01:18 +0200
+Subject: [PATCH] Requeue RUNNING jobs on startup
+
+Fix https://github.com/learningequality/kolibri/issues/9280
+---
+ kolibri/core/tasks/storage.py | 14 ++++++++++++++
+ kolibri/core/tasks/worker.py  |  8 ++++++++
+ 2 files changed, 22 insertions(+)
+
+diff --git a/kolibri/core/tasks/storage.py b/kolibri/core/tasks/storage.py
+index 529fe074d0..15d41b7984 100644
+--- a/kolibri/core/tasks/storage.py
++++ b/kolibri/core/tasks/storage.py
+@@ -191,6 +191,17 @@ class Storage(StorageMixin):
+ 
+             return [self._orm_to_job(job) for job in jobs]
+ 
++    def get_running_jobs(self, queues=None):
++        with self.session_scope() as s:
++            q = s.query(ORMJob).filter(ORMJob.state == State.RUNNING)
++
++            if queues:
++                q = q.filter(ORMJob.queue.in_(queues))
++
++            jobs = q.order_by(ORMJob.time_created).all()
++
++            return [self._orm_to_job(job) for job in jobs]
++
+     def get_all_jobs(self, queue=None):
+         with self.session_scope() as s:
+             q = s.query(ORMJob)
+@@ -280,6 +291,9 @@ class Storage(StorageMixin):
+     def mark_job_as_running(self, job_id):
+         self._update_job(job_id, State.RUNNING)
+ 
++    def mark_job_as_queued(self, job_id):
++        self._update_job(job_id, State.QUEUED)
++
+     def complete_job(self, job_id, result=None):
+         self._update_job(job_id, State.COMPLETED, result=result)
+ 
+diff --git a/kolibri/core/tasks/worker.py b/kolibri/core/tasks/worker.py
+index d2f848abde..270212b57c 100644
+--- a/kolibri/core/tasks/worker.py
++++ b/kolibri/core/tasks/worker.py
+@@ -26,6 +26,8 @@ class Worker(object):
+ 
+         self.storage = Storage(connection)
+ 
++        self.requeue_stalled_jobs()
++
+         # Regular workers run both 'high' and 'regular' priority jobs.
+         # High workers run only 'high' priority jobs.
+         self.regular_workers = regular_workers
+@@ -34,6 +36,12 @@ class Worker(object):
+         self.workers = self.start_workers()
+         self.job_checker = self.start_job_checker()
+ 
++    def requeue_stalled_jobs(self):
++        logger.info("Requeuing stalled jobs.")
++        for job in self.storage.get_running_jobs():
++            logger.info("Requeuing job id {}.".format(job.job_id))
++            self.storage.mark_job_as_queued(job.job_id)
++
+     def shutdown_workers(self, wait=True):
+         # First cancel all running jobs
+         # Coerce to a list, as otherwise the iterable can change size
+-- 
+2.36.1
+


### PR DESCRIPTION
This patch was merged upstream, so bringing it downstream meantime we're
using Kolibri 0.15

https://github.com/learningequality/kolibri/pull/9352

https://phabricator.endlessm.com/T33413