### PR TITLE
Proper cmdlinetools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,7 @@ install:
 logcat:
 	$(ADB) logcat | grep -i -E "python|kolibr| `$(ADB) shell ps | grep ' org.endlessos.Key$$' | tr -s [:space:] ' ' | cut -d' ' -f2` " | grep -E -v "WifiTrafficPoller|localhost:5000|NetworkManagementSocketTagger|No jobs to start"
 
-$(SDK)/cmdline-tools:
+$(SDK)/cmdline-tools/latest/bin/sdkmanager:
 	@echo "Downloading Android SDK command line tools"
 	wget https://dl.google.com/android/repository/commandlinetools-$(PLATFORM)-7583922_latest.zip
 	rm -rf cmdline-tools
@@ -200,7 +200,7 @@ $(SDK)/cmdline-tools:
 	rm -rf cmdline-tools
 	rm commandlinetools-$(PLATFORM)-7583922_latest.zip
 
-sdk:
+sdk: $(SDK)/cmdline-tools/latest/bin/sdkmanager
 	yes y | $(SDK)/cmdline-tools/latest/bin/sdkmanager "platform-tools"
 	yes y | $(SDK)/cmdline-tools/latest/bin/sdkmanager "platforms;android-$(ANDROID_API)"
 	yes y | $(SDK)/cmdline-tools/latest/bin/sdkmanager "system-images;android-$(ANDROID_API);default;x86_64"
@@ -215,8 +215,6 @@ sdk:
 # The SDK installations will take a little time, but will not attempt to redownload if already installed.
 setup:
 	$(MAKE) guard-ANDROID_HOME
-	mkdir -p $(SDK)
-	$(MAKE) $(SDK)/cmdline-tools
 	$(MAKE) sdk
 	@echo "Make sure to set the necessary environment variables"
 	@echo "export ANDROIDSDK=$(SDK)"

--- a/Makefile
+++ b/Makefile
@@ -190,20 +190,25 @@ logcat:
 	$(ADB) logcat | grep -i -E "python|kolibr| `$(ADB) shell ps | grep ' org.endlessos.Key$$' | tr -s [:space:] ' ' | cut -d' ' -f2` " | grep -E -v "WifiTrafficPoller|localhost:5000|NetworkManagementSocketTagger|No jobs to start"
 
 $(SDK)/cmdline-tools:
-	@echo "Downloading Android SDK build tools"
+	@echo "Downloading Android SDK command line tools"
 	wget https://dl.google.com/android/repository/commandlinetools-$(PLATFORM)-7583922_latest.zip
-	unzip commandlinetools-$(PLATFORM)-7583922_latest.zip -d $(SDK)
+	rm -rf cmdline-tools
+	unzip commandlinetools-$(PLATFORM)-7583922_latest.zip
+# This is unfortunate since it will download the command line tools
+# again, but after this it will be properly installed and updatable.
+	yes y | ./cmdline-tools/bin/sdkmanager "cmdline-tools;latest" --sdk_root=$(SDK)
+	rm -rf cmdline-tools
 	rm commandlinetools-$(PLATFORM)-7583922_latest.zip
 
 sdk:
-	yes y | $(SDK)/cmdline-tools/bin/sdkmanager "platform-tools" --sdk_root=$(SDK)
-	yes y | $(SDK)/cmdline-tools/bin/sdkmanager "platforms;android-$(ANDROID_API)" --sdk_root=$(SDK)
-	yes y | $(SDK)/cmdline-tools/bin/sdkmanager "system-images;android-$(ANDROID_API);default;x86_64" --sdk_root=$(SDK)
-	yes y | $(SDK)/cmdline-tools/bin/sdkmanager "build-tools;30.0.3" --sdk_root=$(SDK)
-	yes y | $(SDK)/cmdline-tools/bin/sdkmanager "ndk;$(ANDROIDNDKVER)" --sdk_root=$(SDK)
+	yes y | $(SDK)/cmdline-tools/latest/bin/sdkmanager "platform-tools"
+	yes y | $(SDK)/cmdline-tools/latest/bin/sdkmanager "platforms;android-$(ANDROID_API)"
+	yes y | $(SDK)/cmdline-tools/latest/bin/sdkmanager "system-images;android-$(ANDROID_API);default;x86_64"
+	yes y | $(SDK)/cmdline-tools/latest/bin/sdkmanager "build-tools;30.0.3"
+	yes y | $(SDK)/cmdline-tools/latest/bin/sdkmanager "ndk;$(ANDROIDNDKVER)"
 	ln -sfT ndk/$(ANDROIDNDKVER) $(SDK)/ndk-bundle
 	@echo "Accepting all licenses"
-	yes | $(SDK)/cmdline-tools/bin/sdkmanager --licenses --sdk_root=$(SDK)
+	yes | $(SDK)/cmdline-tools/latest/bin/sdkmanager --licenses
 
 # All of these commands are non-destructive, so if the cmdline-tools are already installed, make will skip
 # based on the directory existing.


### PR DESCRIPTION
Combined with https://github.com/endlessm/python-for-android/pull/3, this allows using OpenJDK 11 instead of OpenJDK 8. That's the only reason to be using the Ubuntu 16.04 image.

https://phabricator.endlessm.com/T33535