### PR TITLE
Papercuts

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,6 +36,12 @@ pipeline {
 
         stage('Distro') {
             steps {
+                // p4a's cache invalidation has tons of bugs. Clean the
+                // kolibri distribution to ensure we get all the current
+                // code copied into it. This may need to be extended to
+                // include builds so that all that's left is the
+                // download cache.
+                sh 'p4a clean dists'
                 sh 'make p4a_android_distro'
             }
         }

--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ p4a_android_distro: needs-android-dirs
 	$(P4A) create $(ARCH_OPTIONS)
 
 .PHONY: needs-version
-needs-version:
+needs-version: src/kolibri
 	$(eval APK_VERSION ?= $(shell python3 scripts/version.py apk_version))
 	$(eval BUILD_NUMBER ?= $(shell python3 scripts/version.py build_number))
 

--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,7 @@ kolibri.apk.unsigned: p4a_android_distro src/kolibri src/apps-bundle needs-versi
 .PHONY: kolibri.aab
 # Build the signed version of the aab
 # For some reason, p4a defauls to adding a final '-' to the filename, so we remove it in the final step.
-kolibri.aab: p4a_android_distro src/kolibri needs-version
+kolibri.aab: p4a_android_distro src/kolibri src/apps-bundle needs-version
 	$(MAKE) guard-P4A_RELEASE_KEYSTORE
 	$(MAKE) guard-P4A_RELEASE_KEYALIAS
 	$(MAKE) guard-P4A_RELEASE_KEYSTORE_PASSWD

--- a/src/initialization.py
+++ b/src/initialization.py
@@ -14,6 +14,8 @@ from jnius import autoclass
 
 # initialize logging before loading any third-party modules, as they may cause logging to get configured.
 logging.basicConfig(level=logging.DEBUG)
+jnius_logger = logging.getLogger("jnius")
+jnius_logger.setLevel(logging.INFO)
 
 apply_android_workarounds()
 


### PR DESCRIPTION
A few fixes I've come across lately. I think the Jenkins one is important as I've seen it fail builds with cached files it shouldn't be using. For example, it copies its `build.py` into the distribution and reuses it until it's forcefully deleted. That's fine when p4a never changes, but we often make changes to it.