### PR TITLE
Improve backend server reliability

### DIFF
--- a/.p4a
+++ b/.p4a
@@ -10,7 +10,7 @@
 --minsdk 21
 --permission ACCESS_NETWORK_STATE
 --permission FOREGROUND_SERVICE
---service server:server.py
+--service server:server.py:foreground:sticky
 --service remoteshell:remoteshell.py
 --presplash assets/presplash.png
 --presplash-color #F15A22

--- a/src/server.py
+++ b/src/server.py
@@ -8,6 +8,9 @@ from kolibri.main import initialize
 from kolibri.main import start
 from kolibri.plugins.app.utils import interface
 from kolibri.utils.conf import KOLIBRI_HOME
+from kolibri.utils.server import _read_pid_file
+from kolibri.utils.server import PID_FILE
+from kolibri.utils.server import STATUS_RUNNING
 
 logging.info("Entering Kolibri server service")
 
@@ -21,5 +24,12 @@ interface.register(share_file=share_by_intent)
 
 logging.info("Home folder: {}".format(KOLIBRI_HOME))
 logging.info("Timezone: {}".format(os.environ.get("TZ", "(default)")))
+
+args = {}
+_, port, _, status = _read_pid_file(PID_FILE)
+# Possibly a killed process so we try to use the same port
+if status == STATUS_RUNNING and port:
+    args["port"] = port
+
 # start the kolibri server
-start()
+start(**args)


### PR DESCRIPTION
This patch makes the service foreground and sticky to ensure that the
service is reloaded if it crashes for some reason.

https://phabricator.endlessm.com/T33718