### PR TITLE
Make Jenkins builds more robust

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,10 +34,9 @@ pipeline {
         stage('Distro') {
             steps {
                 // p4a's cache invalidation has tons of bugs. Clean the
-                // kolibri distribution to ensure we get all the current
-                // code copied into it. This may need to be extended to
-                // include builds so that all that's left is the
-                // download cache.
+                // builds and distributions to ensure we get all the
+                // current code copied into it.
+                sh 'p4a clean builds'
                 sh 'p4a clean dists'
                 sh 'make p4a_android_distro'
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,14 +3,6 @@
 pipeline {
     agent {
         dockerfile {
-            // We're trying to recreate what rundocker.sh does. Jenkins
-            // will already run as the Jenkins user with the checkout
-            // mounted and set to the current workdir. What we need is
-            // to mount the cache volume at the expected location and
-            // set HOME to that path.
-            args '--mount type=volume,src=kolibri-android-cache,dst=/cache ' +
-                '--env HOME=/cache'
-
             // Try to use the same node to make use of caching.
             reuseNode true
         }
@@ -21,6 +13,10 @@ pipeline {
         // FIXME: It would be nice to cache this somehow.
         // FIXME: Go back to use an official release once that happens on GitHub for 0.16.
         KOLIBRI_WHL_URL = 'https://buildkite.com/organizations/learningequality/pipelines/kolibri-python-package/builds/6198/jobs/0182fefa-da30-4683-a144-e7a7c0d3067c/artifacts/0182ff0f-a9e4-4384-bf26-d941243db21c'
+
+        // Both p4a and gradle cache outputs in the home directory.
+        // Point it inside the workspace.
+        HOME = "$WORKSPACE/_cache"
     }
 
 

--- a/Makefile
+++ b/Makefile
@@ -11,13 +11,6 @@ ARCH_OPTIONS := $(foreach arch,$(ARCHES),--arch=$(arch))
 
 OSNAME := $(shell uname -s)
 
-# Usually, P4A prepends "ccache" to CC and CXX. However, this causes certain
-# builds to behave unexpectedly, such as inside the zstandard recipe. Instead,
-# we will add /usr/lib/ccache to $PATH so ccache will be used automatically,
-# and set USE_CCACHE=0 so P4A will use compiler commands as usual.
-export USE_CCACHE := 0
-export PATH := /usr/lib/ccache:$(PATH)
-
 ifeq ($(OSNAME), Darwin)
 	PLATFORM := macosx
 else

--- a/p4a-recipes/zstandard/__init__.py
+++ b/p4a-recipes/zstandard/__init__.py
@@ -1,3 +1,5 @@
+import os
+
 from pythonforandroid.recipe import CompiledComponentsPythonRecipe
 
 
@@ -12,6 +14,14 @@ class ZStandardRecipe(CompiledComponentsPythonRecipe):
         "https://pypi.python.org/packages/source/z/zstandard/zstandard-{version}.tar.gz"
     )
     depends = ["cffi", "setuptools"]
+
+    # Local patches need to be an absolute paths or they won't be found
+    # by patch.
+    #
+    # https://github.com/kivy/python-for-android/issues/2623
+    patches = [
+        os.path.realpath(os.path.join(os.path.dirname(__file__), "preprocessor.patch")),
+    ]
 
     call_hostpython_via_targetpython = False  # For setuptools
 

--- a/p4a-recipes/zstandard/preprocessor.patch
+++ b/p4a-recipes/zstandard/preprocessor.patch
@@ -1,0 +1,59 @@
+From ccb555d367ad711bb0256b9fdcfd8b5c78aab6e7 Mon Sep 17 00:00:00 2001
+From: Dan Nicholson <dbn@endlessos.org>
+Date: Thu, 21 Jul 2022 15:22:20 -0600
+Subject: [PATCH] cffi: Use the distutils preprocessor when available
+
+On Unix like systems, distutils will usually set the preprocessor
+attribute to the appropriate command. On MSVC it never sets the
+preprocessor, though. In either case, try to use it and only fallback to
+using the compiler if needed. Using compiler.compiler[0] breaks use of
+ccache when inserted in the CC environment variable.
+
+This is a regression from 0d1329ab426dde7dc319905da0656cd44db41988.
+
+Closes #178.
+---
+ make_cffi.py | 15 ++++++++-------
+ 1 file changed, 8 insertions(+), 7 deletions(-)
+
+Upstream: https://github.com/indygreg/python-zstandard/pull/179
+
+diff --git a/make_cffi.py b/make_cffi.py
+index 3029e42..806398f 100644
+--- a/make_cffi.py
++++ b/make_cffi.py
+@@ -40,23 +40,24 @@ if hasattr(compiler, "initialize"):
+ # environment variables like CC.
+ distutils.sysconfig.customize_compiler(compiler)
+ 
+-# Distutils doesn't set compiler.preprocessor, so invoke the preprocessor
+-# manually.
++# Distutils doesn't always set compiler.preprocessor, so invoke the
++# preprocessor manually when needed.
++args = getattr(compiler, "preprocessor", None)
+ if compiler.compiler_type == "unix":
+-    # Using .compiler respects the CC environment variable.
+-    args = [compiler.compiler[0]]
++    if not args:
++        # Using .compiler respects the CC environment variable.
++        args = [compiler.compiler[0], "-E"]
+     args.extend(
+         [
+-            "-E",
+             "-DZSTD_STATIC_LINKING_ONLY",
+             "-DZDICT_STATIC_LINKING_ONLY",
+         ]
+     )
+ elif compiler.compiler_type == "msvc":
+-    args = [compiler.cc]
++    if not args:
++        args = [compiler.cc, "/EP"]
+     args.extend(
+         [
+-            "/EP",
+             "/DZSTD_STATIC_LINKING_ONLY",
+             "/DZDICT_STATIC_LINKING_ONLY",
+         ]
+-- 
+2.30.2
+


### PR DESCRIPTION
Try harder to avoid p4a's caching issues and restore normal ccache usage to get back some of the time lost. After this, the cached data is:

* p4a downloaded packages
* ccache objects
* gradle objects

I trust `ccache` and `gradle` to DTRT and I've never seen any issues with p4a's download caching.

https://phabricator.endlessm.com/T33880