### PR TITLE
Also clean AABs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ needs-android-dirs:
 
 # Clear out apks
 clean:
-	- rm -rf dist/*.apk src/kolibri tmpenv
+	- rm -rf dist/*.apk dist/*.aab src/kolibri tmpenv
 
 deepclean: clean
 	$(PYTHON_FOR_ANDROID) clean_dists


### PR DESCRIPTION
Now that our Jenkins build is persisting the workspace, there were multiple old AABs around in the `dist` directory.