### PR TITLE
Improve Jenkins version code

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,6 +50,11 @@ pipeline {
         }
 
         stage('Release AAB') {
+            // Don't build the release AAB for PRs.
+            when {
+                expression { !params.ghprbPullId }
+            }
+
             steps {
                 withCredentials(
                     [[$class: 'VaultCertificateCredentialsBinding',

--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,7 @@ p4a_android_distro: needs-android-dirs
 .PHONY: needs-version
 needs-version: src/kolibri
 	$(eval APK_VERSION ?= $(shell python3 scripts/version.py apk_version))
-	$(eval BUILD_NUMBER ?= $(shell python3 scripts/version.py build_number))
+	$(eval APK_BUILD_NUMBER ?= $(shell python3 scripts/version.py build_number))
 
 .PHONY: kolibri.apk
 # Build the signed version of the apk
@@ -159,7 +159,7 @@ kolibri.apk: p4a_android_distro src/kolibri src/apps-bundle src/collections asse
 	$(MAKE) guard-P4A_RELEASE_KEYSTORE_PASSWD
 	$(MAKE) guard-P4A_RELEASE_KEYALIAS_PASSWD
 	@echo "--- :android: Build APK"
-	$(P4A) apk --release --sign $(ARCH_OPTIONS) --version=$(APK_VERSION) --numeric-version=$(BUILD_NUMBER)
+	$(P4A) apk --release --sign $(ARCH_OPTIONS) --version=$(APK_VERSION) --numeric-version=$(APK_BUILD_NUMBER)
 	mkdir -p dist
 	mv kolibri-release-$(APK_VERSION).apk dist/kolibri-release-$(APK_VERSION).apk
 
@@ -168,7 +168,7 @@ kolibri.apk: p4a_android_distro src/kolibri src/apps-bundle src/collections asse
 # For some reason, p4a defauls to adding a final '-' to the filename, so we remove it in the final step.
 kolibri.apk.unsigned: p4a_android_distro src/kolibri src/apps-bundle src/collections assets/loadingScreen needs-version
 	@echo "--- :android: Build APK (unsigned)"
-	$(P4A) apk $(ARCH_OPTIONS) --version=$(APK_VERSION) --numeric-version=$(BUILD_NUMBER)
+	$(P4A) apk $(ARCH_OPTIONS) --version=$(APK_VERSION) --numeric-version=$(APK_BUILD_NUMBER)
 	mkdir -p dist
 	mv kolibri-debug-$(APK_VERSION).apk dist/kolibri-debug-$(APK_VERSION).apk
 
@@ -181,7 +181,7 @@ kolibri.aab: p4a_android_distro src/kolibri src/apps-bundle src/collections asse
 	$(MAKE) guard-P4A_RELEASE_KEYSTORE_PASSWD
 	$(MAKE) guard-P4A_RELEASE_KEYALIAS_PASSWD
 	@echo "--- :android: Build AAB"
-	$(P4A) aab --release --sign $(ARCH_OPTIONS) --version=$(APK_VERSION) --numeric-version=$(BUILD_NUMBER)
+	$(P4A) aab --release --sign $(ARCH_OPTIONS) --version=$(APK_VERSION) --numeric-version=$(APK_BUILD_NUMBER)
 	mkdir -p dist
 	mv kolibri-release-$(APK_VERSION).aab dist/kolibri-release-$(APK_VERSION).aab
 

--- a/scripts/version.py
+++ b/scripts/version.py
@@ -64,25 +64,21 @@ def apk_version():
 def build_number():
     """
     Returns the build number for the apk. This is the mechanism used to understand whether one
-    build is newer than another. Uses buildkite build number with time as local dev backup
+    build is newer than another. Uses jenkins build number with time as local dev backup
     """
 
-    # Patch, due to a build error.
-    # Envar was not being passed into the container this runs in, and the
-    # build submitted to the play store ended up using the dev build number.
-    # We can't go backwards. So we're adding to the one submitted at first.
-    build_base_number = 2008998000
+    # At one point a release was made from the PR job, which had a build
+    # number far ahead of the standard job.
+    build_base_number = 169
 
-    buildkite_build_number = os.getenv("BUILDKITE_BUILD_NUMBER")
-
-    if buildkite_build_number is not None:
-        build_number = build_base_number + 2 * int(buildkite_build_number)
-        return str(build_number)
-
-    alt_build_number = (
-        int(datetime.now().strftime("%y%m%d%H%M")) - build_base_number
-    ) * 2
-    return alt_build_number
+    jenkins_build_number = os.getenv("BUILD_NUMBER")
+    if jenkins_build_number:
+        build_number = build_base_number + int(jenkins_build_number)
+    else:
+        build_number = (
+            int(datetime.now().strftime("%y%m%d%H%M")) - build_base_number
+        ) * 2
+    return build_number
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Reliably calculate the version code from the Jenkins build number and work around a previous release made from the PR job.

https://phabricator.endlessm.com/T33892