### PR TITLE
Set CONTENT_FALLBACK_DIRS after USB URIs set

### DIFF
--- a/src/initialization.py
+++ b/src/initialization.py
@@ -29,6 +29,15 @@ from android_whitenoise import monkeypatch_whitenoise  # noqa: E402
 
 monkeypatch_whitenoise()
 
+
+def set_content_fallback_dirs_env():
+    endless_key_uris = get_endless_key_uris()
+    if endless_key_uris is not None:
+        content_uri = DynamicWhiteNoise.encode_root(endless_key_uris["content"])
+        logging.info("Setting KOLIBRI_CONTENT_FALLBACK_DIRS to %s", content_uri)
+        os.environ["KOLIBRI_CONTENT_FALLBACK_DIRS"] = content_uri
+
+
 signing_org = get_signature_key_issuing_organization()
 if signing_org == "Learning Equality":
     runmode = "android-testing"
@@ -46,11 +55,7 @@ os.environ["LC_ALL"] = "en_US.UTF-8"
 
 os.environ["KOLIBRI_HOME"] = get_home_folder()
 
-endless_key_uris = get_endless_key_uris()
-if endless_key_uris is not None:
-    content_uri = DynamicWhiteNoise.encode_root(endless_key_uris["content"])
-    logging.info("Setting KOLIBRI_CONTENT_FALLBACK_DIRS to %s", content_uri)
-    os.environ["KOLIBRI_CONTENT_FALLBACK_DIRS"] = content_uri
+set_content_fallback_dirs_env()
 
 os.environ["KOLIBRI_APK_VERSION_NAME"] = get_version_name()
 os.environ["DJANGO_SETTINGS_MODULE"] = "kolibri_app_settings"

--- a/src/main.py
+++ b/src/main.py
@@ -241,6 +241,7 @@ def start_kolibri_with_usb():
 
     provision_endless_key_database(key_uris)
     set_endless_key_uris(key_uris)
+    initialization.set_content_fallback_dirs_env()
     start_kolibri()
 
 


### PR DESCRIPTION
When Kolibri was running from a separate service, setting `CONTENT_FALLBACK_DIRS` early in `initialization.py` was fine since the service process wouldn't be spawned until after the initial USB checks. Now Kolibri is running in the main activity, so the environment variable needs to be set immediately after the USB checks, too.

https://phabricator.endlessm.com/T33793