### PR TITLE
Jenkins release pipelines

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,6 +22,10 @@ pipeline {
 
     options {
         ansiColor('xterm')
+
+        // This is needed to allow the upload job to copy the built
+        // artifacts.
+        copyArtifactPermission('kolibri-installer-android-upload')
     }
 
     stages {

--- a/Jenkinsfile-promote
+++ b/Jenkinsfile-promote
@@ -1,0 +1,67 @@
+// Jenkins promote pipeline
+//
+// https://www.jenkins.io/doc/book/pipeline/
+
+pipeline {
+    // Any agent is fine as all the work happens on the controller.
+    agent any
+
+    parameters {
+        string(
+            name: 'VERSION',
+            description: 'Version code to promote',
+            trim: true,
+        )
+        choice(
+            name: 'TRACK',
+            description: 'Release track to promote to',
+            choices: ['alpha', 'beta', 'production'],
+        )
+    }
+
+    stages {
+        stage('Release') {
+            androidApkMove(
+                googleCredentialsId: 'google-play-account',
+                applicationId: 'org.endlessos.Key',
+                // Let Google Play use versionName for releaseName
+                releaseName: '',
+                rolloutPercentage: '100',
+                trackName: params.TRACK,
+                // Use an already uploaded version
+                fromVersionCode: true,
+                versionCodes: params.VERSION,
+            )
+        }
+    }
+
+    post {
+        always {
+            buildDescription("${params.VERSION} ${params.TRACK}")
+        }
+
+        success {
+            emailext (
+                to: 'apps@endlessos.org,$DEFAULT_RECIPIENTS',
+                replyTo: 'apps@endlessos.org',
+                subject: "Released org.endlessos.Key ${params.VERSION} to ${params.TRACK}",
+                body: """\
+Released org.endlessos.Key ${params.VERSION} to ${params.TRACK}".
+
+See Jenkins job $PROJECT_NAME build $BUILD_NUMBER for details.
+
+$BUILD_URL
+"""
+            )
+        }
+
+        failure {
+            emailext (
+                to: 'apps@endlessos.org,$DEFAULT_RECIPIENTS',
+                replyTo: 'apps@endlessos.org',
+                subject: '$DEFAULT_SUBJECT',
+                body: '$DEFAULT_CONTENT',
+            )
+        }
+    }
+}

--- a/Jenkinsfile-upload
+++ b/Jenkinsfile-upload
@@ -1,0 +1,108 @@
+// Jenkins upload pipeline
+//
+// https://www.jenkins.io/doc/book/pipeline/
+
+pipeline {
+    // Any agent is fine as all the work happens in plugins.
+    agent any
+
+    parameters {
+        text(
+            name: 'RELEASE_NOTES',
+            description: '''\
+<p>Release notes in JSON. The expected format is
+an array of objects with <code>language</code> and <code>text</code>
+properties. For example:</p>
+
+<pre>
+[
+  {"language": "en-US", "text": "Fixed a problem"},
+  {"language": "de-DE", "text": "Ein Problem wurde behoben"}
+]
+</pre>''',
+        )
+}
+
+    stages {
+        stage('Copy AAB') {
+            steps {
+                copyArtifacts(
+                    projectName: 'kolibri-installer-android',
+                    selector: lastSuccessful(),
+                    filter: 'dist/kolibri-release-*.aab, dist/version.json',
+                    fingerprintArtifacts: true,
+                )
+            }
+        }
+
+        stage('Upload') {
+            steps {
+                // A bit of pre-processing is needed, so we need to drop
+                // into scripted pipeline mode.
+                script {
+                    // Make sure release notes have been provided.
+                    if (!params.RELEASE_NOTES) {
+                        error('RELEASE_NOTES parameter not set')
+                    }
+
+                    // Make sure there's only a single AAB file.
+                    def pattern = 'kolibri-release-*.aab'
+                    def numFiles = findFiles(glob: pattern).size()
+                    if (files.size() != 1) {
+                        error("${pattern} matched ${numFiles} files")
+                    }
+
+                    def releaseNotes = readJSON(text: params.RELEASE_NOTES)
+                    androidApkUpload(
+                        googleCredentialsId: 'google-play-account',
+                        filesPattern: pattern,
+                        trackName: 'internal',
+                        recentChangeList: releaseNotes,
+                        rolloutPercentage: '100',
+                    )
+                }
+            }
+        }
+    }
+
+    post {
+        always {
+            script {
+                def version = readJSON(file: 'version.json')
+                buildDescription("${version.versionCode} ${version.versionName}")
+            }
+        }
+
+        success {
+            script {
+                def files = findFiles(glob: 'kolibri-release-*.aab')
+                def aab = files[0].name
+                def version = readJSON(file: 'version.json')
+
+                emailext (
+                    to: 'apps@endlessos.org,$DEFAULT_RECIPIENTS',
+                    replyTo: 'apps@endlessos.org',
+                    subject: "Uploaded org.endlessos.Key " +
+                        "${version.versionCode} to internal testing",
+                    body: """\
+Uploaded org.endlessos.Key ${version.versionCode} ${version.versionName} from
+${aab} to internal testing".
+
+See Jenkins job $PROJECT_NAME build $BUILD_NUMBER for details.
+
+$BUILD_URL
+"""
+                )
+            }
+        }
+
+        failure {
+            emailext (
+                to: 'apps@endlessos.org,$DEFAULT_RECIPIENTS',
+                replyTo: 'apps@endlessos.org',
+                subject: '$DEFAULT_SUBJECT',
+                body: '$DEFAULT_CONTENT',
+            )
+        }
+    }
+}

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ needs-android-dirs:
 
 # Clear out apks
 clean:
-	- rm -rf dist/*.apk dist/*.aab src/kolibri tmpenv
+	- rm -rf dist/*.apk dist/*.aab dist/version.json src/kolibri tmpenv
 
 deepclean: clean
 	$(PYTHON_FOR_ANDROID) clean_dists
@@ -147,10 +147,22 @@ needs-version: src/kolibri
 	$(eval APK_VERSION ?= $(shell python3 scripts/version.py apk_version))
 	$(eval APK_BUILD_NUMBER ?= $(shell python3 scripts/version.py build_number))
 
+dist/version.json: needs-version
+	mkdir -p dist
+	echo '{"versionCode": "$(APK_BUILD_NUMBER)", "versionName": "$(APK_VERSION)"}' > $@
+
+DIST_DEPS = \
+	p4a_android_distro \
+	src/kolibri \
+	src/apps-bundle \
+	src/collections \
+	assets/loadingScreen \
+	needs-version \
+	dist/version.json
+
 .PHONY: kolibri.apk
 # Build the signed version of the apk
-# For some reason, p4a defauls to adding a final '-' to the filename, so we remove it in the final step.
-kolibri.apk: p4a_android_distro src/kolibri src/apps-bundle src/collections assets/loadingScreen needs-version
+kolibri.apk: $(DIST_DEPS)
 	$(MAKE) guard-P4A_RELEASE_KEYSTORE
 	$(MAKE) guard-P4A_RELEASE_KEYALIAS
 	$(MAKE) guard-P4A_RELEASE_KEYSTORE_PASSWD
@@ -162,8 +174,7 @@ kolibri.apk: p4a_android_distro src/kolibri src/apps-bundle src/collections asse
 
 .PHONY: kolibri.apk.unsigned
 # Build the unsigned debug version of the apk
-# For some reason, p4a defauls to adding a final '-' to the filename, so we remove it in the final step.
-kolibri.apk.unsigned: p4a_android_distro src/kolibri src/apps-bundle src/collections assets/loadingScreen needs-version
+kolibri.apk.unsigned: $(DIST_DEPS)
 	@echo "--- :android: Build APK (unsigned)"
 	$(P4A) apk $(ARCH_OPTIONS) --version=$(APK_VERSION) --numeric-version=$(APK_BUILD_NUMBER)
 	mkdir -p dist
@@ -171,8 +182,7 @@ kolibri.apk.unsigned: p4a_android_distro src/kolibri src/apps-bundle src/collect
 
 .PHONY: kolibri.aab
 # Build the signed version of the aab
-# For some reason, p4a defauls to adding a final '-' to the filename, so we remove it in the final step.
-kolibri.aab: p4a_android_distro src/kolibri src/apps-bundle src/collections assets/loadingScreen needs-version
+kolibri.aab: $(DIST_DEPS)
 	$(MAKE) guard-P4A_RELEASE_KEYSTORE
 	$(MAKE) guard-P4A_RELEASE_KEYALIAS
 	$(MAKE) guard-P4A_RELEASE_KEYSTORE_PASSWD


### PR DESCRIPTION
This adds 2 Jenkins pipeline scripts for releasing in Google Play:

* `Jenkinsfile-upload` would be used to upload a built version to the internal testing track.
* `Jenkinsfile-promote` would be used to promote an existing version to another release track.

This uses the Jenkins [Google Play Android Publisher](https://plugins.jenkins.io/google-play-android-publisher/) plugin to do the heavy lifting. If we need more control, we'll probably need to write a script that interacts with the Google APIs directly.

https://phabricator.endlessm.com/T33465