### PR TITLE
Explore depencency: Specify the patch version

### DIFF
--- a/.p4a
+++ b/.p4a
@@ -5,7 +5,7 @@
 --private "src"
 --local-recipes "p4a-recipes"
 --orientation sensor
---requirements python3,android,pyjnius,genericndkbuild,sqlite3,cryptography,twisted,attrs,bcrypt,service_identity,pyasn1,pyasn1_modules,pyopenssl,openssl,six,liblzma,zstandard,beautifulsoup4==4.10.0,zimply_core,kolibri_explore_plugin~=3.0,kolibri_zim_plugin
+--requirements python3,android,pyjnius,genericndkbuild,sqlite3,cryptography,twisted,attrs,bcrypt,service_identity,pyasn1,pyasn1_modules,pyopenssl,openssl,six,liblzma,zstandard,beautifulsoup4==4.10.0,zimply_core,kolibri_explore_plugin~=3.0.2,kolibri_zim_plugin
 --android-api 31
 --minsdk 24
 --allow-minsdk-ndkapi-mismatch


### PR DESCRIPTION
Keep using the compatible release clause [1] but also specify the patch version. Otherwise if eg 3.0.1 was installed then 3.0.2 won't be installed.

[1] https://peps.python.org/pep-0440/#compatible-release

https://phabricator.endlessm.com/T33835