### PR TITLE
Finally hook app with new onboarding

### DIFF
--- a/src/java/org/learningequality/FullScreen.java
+++ b/src/java/org/learningequality/FullScreen.java
@@ -4,6 +4,8 @@ import android.app.Activity;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.view.View;
+import android.content.Context;
+import android.content.SharedPreferences;
 import android.webkit.WebChromeClient;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
@@ -52,8 +54,10 @@ public class FullScreen {
         mWebView.addJavascriptInterface(new Object() {
             @JavascriptInterface
             public void startWithNetwork(String packId) {
-                // TODO: How can we pass the packId as parameter to
-                // the startWithNetwork runnable? Logging it for now.
+                SharedPreferences sharedPref =  mActivity.getSharedPreferences(mActivity.getPackageName(), Context.MODE_PRIVATE);
+                SharedPreferences.Editor editor = sharedPref.edit();
+                editor.putString("initial_content_pack_id", packId);
+                editor.commit();
                 Log.v("Endless Key", packId);
                 startWithNetwork.run();
             }

--- a/src/kolibri_android/android_utils.py
+++ b/src/kolibri_android/android_utils.py
@@ -164,6 +164,13 @@ def get_home_folder():
     return os.path.join(kolibri_home_file.toString(), "KOLIBRI_DATA")
 
 
+def get_initial_content_pack_id():
+    preferences = get_preferences()
+    pack_id = preferences.getString("initial_content_pack_id", None)
+    logger.debug("Initial content pack ID: %s", pack_id)
+    return pack_id
+
+
 def get_endless_key_uris():
     preferences = get_preferences()
     content_uri = preferences.getString("key_content_uri", None)

--- a/src/kolibri_android/kolibri_utils.py
+++ b/src/kolibri_android/kolibri_utils.py
@@ -6,6 +6,7 @@ from importlib.util import find_spec
 from .android_utils import get_android_node_id
 from .android_utils import get_endless_key_uris
 from .android_utils import get_home_folder
+from .android_utils import get_initial_content_pack_id
 from .android_utils import get_signature_key_issuing_organization
 from .android_utils import get_timezone_name
 from .android_utils import get_version_name
@@ -39,6 +40,8 @@ def init_kolibri(**kwargs):
 
     _init_kolibri_env()
     _update_kolibri_content_fallback_dirs()
+    _update_explore_plugin_options()
+
     _monkeypatch_whitenoise()
 
     for plugin_name in DISABLED_PLUGINS:
@@ -95,6 +98,14 @@ def _init_kolibri_env():
     # id that is known to be hardcoded in many devices.
     if node_id and len(node_id) >= 16 and node_id != "9774d56d682e549c":
         os.environ["MORANGO_NODE_ID"] = node_id
+
+
+def _update_explore_plugin_options():
+    pack_id = get_initial_content_pack_id()
+    if pack_id is not None:
+        os.environ["KOLIBRI_INITIAL_CONTENT_PACK"] = pack_id
+    else:
+        os.environ["KOLIBRI_USE_EK_IGUANA_PAGE"] = "1"
 
 
 def _update_kolibri_content_fallback_dirs():

--- a/src/kolibri_android/main_activity/activity.py
+++ b/src/kolibri_android/main_activity/activity.py
@@ -135,7 +135,7 @@ class MainActivity(BaseActivity):
             try:
                 key_uris = choose_endless_key_uris()
             except PermissionsWrongFolderError:
-                evaluate_javascript("WelcomeApp.ShowPermissionswrongfolder()")
+                evaluate_javascript("WelcomeApp.showPermissionsWrongFolder()")
                 return
             except PermissionsCancelledError:
                 evaluate_javascript("WelcomeApp.showPermissionsCancelled()")
@@ -147,13 +147,9 @@ class MainActivity(BaseActivity):
         self.start_kolibri()
 
     def _on_start_with_network(self):
-        # TODO: Receive packId as parameter, store it in Android app
-        # preferences, and pass it as Explore plugin option through an
-        # environment variable.
         self.TO_RUN_IN_MAIN = self.start_kolibri
 
     def _on_start_with_usb(self):
-        # TODO: Show grant access view
         self.TO_RUN_IN_MAIN = self.start_kolibri_with_usb
 
     def _on_loading_ready(self):
@@ -177,8 +173,6 @@ class MainActivity(BaseActivity):
 
         else:
             logging.info("Starting network mode")
-            # TODO: Read packId from Android app preferences, and pass
-            # it as Explore plugin option through an environment variable.
             self.TO_RUN_IN_MAIN = self.start_kolibri
 
     def check_has_any_external_storage_device(self):


### PR DESCRIPTION
- Network: Pass the initial pack ID to the Explore plugin.
- USB: Pass USE_EK_IGUANA_PAGE to the Explore plugin.

Both through Kolibri settings.

The initial pack is stored in Android preferences from Java for simplicity.

https://phabricator.endlessm.com/T34363