### PR TITLE
Restore current URL

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,3 +1,0 @@
-from kolibri_android.main_activity.__main__ import main
-
-main()


### PR DESCRIPTION
When the app is stopped, store the current URL path. When the app is started, restore the URL by passing it as the next URL to the initialization URL.

https://phabricator.endlessm.com/T34173

----

This pull request is a replacement for #69, rebased against the current develop branch.