### PR TITLE
Activity lifecycle: Stop only the services on stop

### DIFF
--- a/src/kolibri_android/main_activity/activity.py
+++ b/src/kolibri_android/main_activity/activity.py
@@ -104,7 +104,7 @@ class MainActivity(BaseActivity):
             # run after thsi one, so we need to keep track of the webview's
             # URL before switching to the loading screen.
             self._last_kolibri_path = self._get_current_kolibri_path()
-            self._kolibri_bus.transition("IDLE")
+            self._kolibri_bus.stop_services()
         elif self._kolibri_bus.state != "IDLE":
             logging.warning(
                 f"Kolibri is unable to stop because its state is '{self._kolibri_bus.state}"
@@ -116,7 +116,9 @@ class MainActivity(BaseActivity):
         if self._kolibri_bus is None:
             return
 
-        if self._kolibri_bus.can_transition("START"):
+        if self._kolibri_bus.state == "START":
+            self._kolibri_bus.start_services()
+        elif self._kolibri_bus.can_transition("START"):
             self._last_kolibri_path = None
             self._kolibri_bus.transition("START")
         elif self._kolibri_bus.state != "START":

--- a/src/kolibri_android/main_activity/kolibri_bus.py
+++ b/src/kolibri_android/main_activity/kolibri_bus.py
@@ -12,11 +12,36 @@ from kolibri.utils.server import ZipContentServerPlugin
 from magicbus.plugins import SimplePlugin
 
 
+class PausableServicesPlugin(ServicesPlugin):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._started = False
+        self._stopped = False
+
+    def START(self):
+        if not self._started:
+            logging.debug("PausableServicesPlugin full start'")
+            super().START()
+            self._started = True
+        elif self._stopped:
+            logging.debug("PausableServicesPlugin partial start'")
+            from kolibri.core.tasks.main import initialize_workers
+
+            self.worker = initialize_workers()
+            self._stopped = False
+        else:
+            logging.debug("PausableServicesPlugin skip start'")
+
+    def STOP(self):
+        super().STOP()
+        self._stopped = True
+
+
 class KolibriAppProcessBus(BaseKolibriProcessBus):
     def __init__(self, *args, enable_zeroconf=True, **kwargs):
         super(KolibriAppProcessBus, self).__init__(*args, **kwargs)
 
-        self._services = ServicesPlugin(self)
+        self._services = PausableServicesPlugin(self)
         self._services.subscribe()
 
         if enable_zeroconf:

--- a/src/kolibri_android/main_activity/kolibri_bus.py
+++ b/src/kolibri_android/main_activity/kolibri_bus.py
@@ -16,7 +16,8 @@ class KolibriAppProcessBus(BaseKolibriProcessBus):
     def __init__(self, *args, enable_zeroconf=True, **kwargs):
         super(KolibriAppProcessBus, self).__init__(*args, **kwargs)
 
-        ServicesPlugin(self).subscribe()
+        self._services = ServicesPlugin(self)
+        self._services.subscribe()
 
         if enable_zeroconf:
             ZeroConfPlugin(self, self.port).subscribe()
@@ -48,6 +49,12 @@ class KolibriAppProcessBus(BaseKolibriProcessBus):
                 return True
 
         return False
+
+    def stop_services(self):
+        self._services.STOP()
+
+    def start_services(self):
+        self._services.START()
 
     def can_transition(self, to_state: str) -> bool:
         return (self.state, to_state) in self.transitions


### PR DESCRIPTION
On stop: stop only the Kolibri services by directly calling ServicesPlugin.STOP.

On resume: if the Kolibri bus is already started, start the services. If not, transition the bus to the START state which should start the services too.

https://phabricator.endlessm.com/T34626