### PR TITLE
README: Add a note for p4a commnad not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ To download a Kolibri WHL file, you can use `make whl=<URL>` from the command li
 
 6. Run `make kolibri.apk.unsigned` to build the apk. Watch for success at the end, or errors, which might indicate missing build dependencies or build errors. If successful, there should be an APK in the `dist/` directory.
 
+PS. If `p4a` command is not found, please check the ticket: ["p4a: command not found"](https://github.com/kivy/python-for-android/issues/1167). If you installed it with `--user`, make sure that `~/.local/bin` is in your `$PATH`.
+
 ## Build on Toolbox
 
 Toolbox allows a mixture of the above build processes by providing a


### PR DESCRIPTION
The python-for-android providing "p4a" command is installed from the requirements.txt in this repository. The installation is bounded in the user enviroment by default, not global.

However, not every distribution's environment variable "PATH" includes the user's HOME path "~/.local/bin". That leads the "p4a" command in "~/.local/bin" becoming missed. So, add this note directing to the solution: "p4a: command not found" [1].

[1]: https://github.com/kivy/python-for-android/issues/1167