### PR TITLE
Spoof a desktop user agent to appease Unity

### DIFF
--- a/src/java/org/learningequality/KolibriAndroidHelper.java
+++ b/src/java/org/learningequality/KolibriAndroidHelper.java
@@ -148,6 +148,14 @@ public class KolibriAndroidHelper {
         mMainWebView.setWebChromeClient(mChrome);
 
         mMainWebView.getSettings().setAllowFileAccess(true);
+
+        enableDesktopMode();
+    }
+
+    private void enableDesktopMode() {
+        mMainWebView.getSettings().setUserAgentString(
+            mMainWebView.getSettings().getUserAgentString().replace("Android", "Human")
+        );
     }
 
     private class MyChrome extends WebChromeClient {


### PR DESCRIPTION
The Unity web loader exits early if the browser looks like a mobile browser. We can work around this by setting a user agent which doesn't mention "Android".

https://phabricator.endlessm.com/T33602