### PR TITLE
Add plugin to send Firebase Analytics events

### DIFF
--- a/src/firebase_plugin/__init__.py
+++ b/src/firebase_plugin/__init__.py
@@ -1,0 +1,2 @@
+__version__ = "0.0.1"
+default_app_config = "firebase_plugin.apps.FirebaseConfig"

--- a/src/firebase_plugin/apps.py
+++ b/src/firebase_plugin/apps.py
@@ -1,0 +1,13 @@
+import logging
+
+from django.apps import AppConfig
+
+logger = logging.getLogger(__name__)
+
+
+class FirebaseConfig(AppConfig):
+    name = "firebase_plugin"
+
+    def ready(self):
+        logger.info("Importing firebase_plugin signal handlers")
+        from . import signals  # noqa: F401

--- a/src/firebase_plugin/kolibri_plugin.py
+++ b/src/firebase_plugin/kolibri_plugin.py
@@ -1,0 +1,9 @@
+import logging
+
+from kolibri.plugins import KolibriPluginBase
+
+logger = logging.getLogger(__name__)
+
+
+class FirebasePlugin(KolibriPluginBase):
+    pass

--- a/src/firebase_plugin/signals.py
+++ b/src/firebase_plugin/signals.py
@@ -1,0 +1,84 @@
+import logging
+
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+from jnius import autoclass
+from kolibri.core.content.models import ContentNode
+from kolibri.core.logger.models import ContentSummaryLog
+from kolibri_android.android_utils import get_activity
+
+# from kolibri.core.logger.models import ContentSessionLog
+
+logger = logging.getLogger(__name__)
+
+Bundle = autoclass("android.os.Bundle")
+Event = autoclass("com.google.firebase.analytics.FirebaseAnalytics$Event")
+FirebaseAnalytics = autoclass("com.google.firebase.analytics.FirebaseAnalytics")
+Param = autoclass("com.google.firebase.analytics.FirebaseAnalytics$Param")
+
+
+def send_content_event(channel_id, content_id, node_id, kind):
+    items = []
+    channel = Bundle()
+    channel.putString(Param.ITEM_ID, channel_id)
+    channel.putString(Param.ITEM_CATEGORY, "channel")
+    items.append(channel)
+    content = Bundle()
+    content.putString(Param.ITEM_ID, content_id)
+    content.putString(Param.ITEM_CATEGORY, "content")
+    content.putString(Param.ITEM_CATEGORY2, kind)
+    items.append(content)
+    if node_id:
+        node = Bundle()
+        node.putString(Param.ITEM_ID, node_id)
+        node.putString(Param.ITEM_CATEGORY, "node")
+        node.putString(Param.ITEM_CATEGORY2, kind)
+        items.append(node)
+    params = Bundle()
+    params.putParcelableArray(Param.ITEMS, items)
+
+    context = get_activity()
+    analytics = FirebaseAnalytics.getInstance(context)
+    logger.info(
+        "Logging event channel=%s content=%s kind=%s node=%s",
+        channel_id,
+        content_id,
+        kind,
+        node_id,
+    )
+    analytics.logEvent(Event.VIEW_ITEM, params)
+
+
+# @receiver(post_save, sender=ContentSessionLog)
+# def session_log_updated(sender, instance, created, **kwargs):
+#     node_id = instance.extra_fields.get("context", {}).get("node_id")
+#     logger.debug(
+#         "channel_id=%s content_id=%s node_id=%s kind=%s %s progress=%f %s",
+#         instance.channel_id,
+#         instance.content_id,
+#         node_id,
+#         instance.kind,
+#         instance.extra_fields,
+#         instance.progress,
+#         "created" if created else "updated",
+#     )
+
+
+@receiver(post_save, sender=ContentSummaryLog)
+def summary_log_updated(sender, instance, **kwargs):
+    node = ContentNode.objects.filter(
+        channel_id=instance.channel_id, content_id=instance.content_id
+    ).first()
+    node_id = node.id if node else None
+    logger.debug(
+        "summary channel_id=%s content_id=%s node_id=%s kind=%s %s time_spent=%f progress=%f",
+        instance.channel_id,
+        instance.content_id,
+        node_id,
+        instance.kind,
+        instance.extra_fields,
+        instance.time_spent,
+        instance.progress,
+    )
+
+    send_content_event(instance.channel_id, instance.content_id, node_id, instance.kind)

--- a/src/kolibri_android/kolibri_utils.py
+++ b/src/kolibri_android/kolibri_utils.py
@@ -32,6 +32,7 @@ REQUIRED_PLUGINS = [
 OPTIONAL_PLUGINS = [
     "kolibri_explore_plugin",
     "kolibri_zim_plugin",
+    "firebase_plugin",
 ]
 
 


### PR DESCRIPTION
We're already using Firebase for Crashlytics, so we're already getting some generic events in Firebase Analytics. This plugin hooks into the Kolibri content logs to send custom events to Firebase. That will allow a rich analysis of what content users are viewing.

This is working but just a draft for the moment as I'm not sure this is actually desired or if this is the best way to send events.