### PR TITLE
Manage Analytics and Crashlytics collection

### DIFF
--- a/.p4a
+++ b/.p4a
@@ -33,3 +33,7 @@
 --depend com.google.firebase:firebase-crashlytics-ndk:18.3.2
 --depend com.google.firebase:firebase-analytics:21.2.0
 --with-debug-symbols
+--debug-manifest-placeholders '[analytics_enabled: "false"]'
+--release-manifest-placeholders '[analytics_enabled: "true"]'
+--meta-data firebase_analytics_collection_enabled=${analytics_enabled}
+--meta-data firebase_crashlytics_collection_enabled=${analytics_enabled}

--- a/README.md
+++ b/README.md
@@ -105,6 +105,54 @@ Alternatively, you can debug the webview directly. Modern Android versions shoul
 
 You could also do so using [Weinre](https://people.apache.org/~pmuellr/weinre/docs/latest/Home.html). Visit the site to learn how to install and setup. You will have to build a custom Kolibri .whl file that contains the weinre script tag in the [base.html file](https://github.com/learningequality/kolibri/blob/develop/kolibri/core/templates/kolibri/base.html).
 
+## Firebase Analytics and Crashlytics
+
+Metrics and crashes are collected from the application using Firebase
+[Analytics][firebase_analytics] and [Crashlytics][firebase_crashlytics].
+In order to see details of the information being collected, increase the
+log levels for the relevant tags:
+
+```
+adb shell setprop log.tag.FA VERBOSE
+adb shell setprop log.tag.FA-SVC VERBOSE
+adb shell setprop log.tag.FirebaseCrashlytics DEBUG
+```
+
+Normally the analytics events are cached locally on disk and sent to the
+Firebase server periodically. In order to send the events immediately,
+enable Analytics debug mode for this application:
+
+```
+adb shell setprop debug.firebase.analytics.app org.endlessos.Key
+```
+
+Finally, events can be seen in the Firebase console
+[DebugView][firebase_debugview] in realtime by setting the application
+as the Android [debug app][android_debugapp]. This requires enabling
+`Developer options` on the device, choosing `Select debug app`, and
+setting it to `org.endlessos.Key`.
+
+[firebase_analytics]: https://firebase.google.com/docs/analytics
+[firebase_crashlytics]: https://firebase.google.com/docs/crashlytics
+[firebase_debugview]: https://firebase.google.com/docs/analytics/debugview
+[android_debugapp]: https://developer.android.com/studio/debug/dev-options#debugging
+
+### Enabling or disabling Analytics and Crashlytics
+
+By default, Analytics and Crashlytics are enabled on release builds and
+disabled on debug builds. This prevents development work from polluting
+our production metrics. Event collection can be explicitly enabled or
+disabled at runtime using the `debug.org.endlessos.key.analytics` system
+property. For example:
+
+```
+adb shell setprop debug.org.endlessos.key.analytics true
+```
+
+The primary use case is for testing analytics development on debug
+builds. However, it can also be used to opt out of analytics by setting
+the property value to `false`. This can be used when testing release
+builds without polluting production metrics.
 
 ## Helpful commands
 - [adb](https://developer.android.com/studio/command-line/adb) is pretty helpful. Here are some useful uses:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 cython
 virtualenv
-git+https://github.com/endlessm/python-for-android@v2022.09.04-endless9#egg=python-for-android
+git+https://github.com/endlessm/python-for-android@v2022.09.04-endless10#egg=python-for-android

--- a/src/kolibri_android/android_utils.py
+++ b/src/kolibri_android/android_utils.py
@@ -30,12 +30,15 @@ logger = logging.getLogger(__name__)
 
 Activity = autoclass("android.app.Activity")
 AndroidString = autoclass("java.lang.String")
+BuildConfig = autoclass("org.endlessos.Key.BuildConfig")
 Context = autoclass("android.content.Context")
 Document = autoclass("android.provider.DocumentsContract$Document")
 DocumentsContract = autoclass("android.provider.DocumentsContract")
 Environment = autoclass("android.os.Environment")
 File = autoclass("java.io.File")
 FileProvider = autoclass("androidx.core.content.FileProvider")
+FirebaseAnalytics = autoclass("com.google.firebase.analytics.FirebaseAnalytics")
+FirebaseCrashlytics = autoclass("com.google.firebase.crashlytics.FirebaseCrashlytics")
 Intent = autoclass("android.content.Intent")
 NotificationBuilder = autoclass("android.app.Notification$Builder")
 NotificationManager = autoclass("android.app.NotificationManager")
@@ -43,6 +46,7 @@ PackageManager = autoclass("android.content.pm.PackageManager")
 PendingIntent = autoclass("android.app.PendingIntent")
 PythonActivity = autoclass("org.kivy.android.PythonActivity")
 Secure = autoclass("android.provider.Settings$Secure")
+SystemProperties = autoclass("android.os.SystemProperties")
 Timezone = autoclass("java.util.TimeZone")
 Toast = autoclass("android.widget.Toast")
 Uri = autoclass("android.net.Uri")
@@ -58,6 +62,9 @@ SDK_INT = ANDROID_VERSION.SDK_INT
 #
 # https://source.chromium.org/chromium/chromium/src/+/main:ash/components/arc/volume_mounter/arc_volume_mounter_bridge.cc;l=51
 MY_FILES_UUID = "0000000000000000000000000000CAFEF00D2019"
+
+# System property configuring Analytics and Crashlytics.
+ANALYTICS_SYSPROP = "debug.org.endlessos.key.analytics"
 
 
 USB_CONTENT_FLAG_FILENAME = "usb_content_flag"
@@ -821,6 +828,48 @@ def _android11_ext_storage_workarounds():
 
 def apply_android_workarounds():
     _android11_ext_storage_workarounds()
+
+
+def setup_analytics():
+    """Enable or disable Firebase Analytics and Crashlytics
+
+    For release builds, they're enabled by default. For debug builds,
+    they're disabled by default. They can be explicitly enabled or
+    disabled using the debug.org.endlessos.key.analytics system
+    property. For example, `adb shell setprop
+    debug.org.endlessos.key.analytics true`.
+    """
+    if BuildConfig.DEBUG:
+        logger.debug("Debug build, analytics default disabled")
+        analytics_default = False
+    else:
+        logger.debug("Release build, analytics default enabled")
+        analytics_default = True
+
+    # Allow explicitly enabling or disabling using a system property.
+    analytics_enabled = SystemProperties.getBoolean(
+        ANALYTICS_SYSPROP,
+        analytics_default,
+    )
+    if analytics_enabled is not analytics_default:
+        logger.debug(
+            "Analytics %s from %s system property",
+            "enabled" if analytics_enabled else "disabled",
+            ANALYTICS_SYSPROP,
+        )
+
+    # Analytics and Crashlytics collection enablement persists across
+    # executions, so actively enable or disable based on the current
+    # settings.
+    logging.info(
+        "%s Firebase Analytics and Crashlytics",
+        "Enabling" if analytics_enabled else "Disabling",
+    )
+    context = get_activity()
+    analytics = FirebaseAnalytics.getInstance(context)
+    crashlytics = FirebaseCrashlytics.getInstance()
+    analytics.setAnalyticsCollectionEnabled(analytics_enabled)
+    crashlytics.setCrashlyticsCollectionEnabled(analytics_enabled)
 
 
 class StartupState(Enum):

--- a/src/kolibri_android/globals.py
+++ b/src/kolibri_android/globals.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from jnius import autoclass
 
 from .android_utils import apply_android_workarounds
+from .android_utils import setup_analytics
 
 
 SCRIPT_PATH = Path(__file__).absolute().parent.parent
@@ -22,6 +23,7 @@ def initialize():
     jnius_logger = logging.getLogger("jnius")
     jnius_logger.setLevel(logging.INFO)
 
+    setup_analytics()
     apply_android_workarounds()
 
     sys.path.append(SCRIPT_PATH.as_posix())


### PR DESCRIPTION
Disable analytics by default on debug builds so that development activity won't pollute our metrics. It also allows explicitly enabling or disabling analytics with the `debug.org.endlessos.key.analytics` system property.

This depends on https://github.com/endlessm/python-for-android/pull/18 and assumes it will be tagged.

See #128.