### PR TITLE
Enable GWP-ASan allocator

### DIFF
--- a/.p4a
+++ b/.p4a
@@ -37,3 +37,4 @@
 --release-manifest-placeholders '[analytics_enabled: "true"]'
 --meta-data firebase_analytics_collection_enabled=${analytics_enabled}
 --meta-data firebase_crashlytics_collection_enabled=${analytics_enabled}
+--extra-manifest-application-arguments 'android:gwpAsanMode="always"'


### PR DESCRIPTION
Enable the GWP-ASan allocator to help detect memory handling bugs in native code. See https://developer.android.com/ndk/guides/gwp-asan for details.

Fixes #125