### PR TITLE
Google Play Install Referrer data

### DIFF
--- a/.p4a
+++ b/.p4a
@@ -32,6 +32,7 @@
 --depend com.google.firebase:firebase-crashlytics:18.3.2
 --depend com.google.firebase:firebase-crashlytics-ndk:18.3.2
 --depend com.google.firebase:firebase-analytics:21.2.0
+--depend com.android.installreferrer:installreferrer:2.2
 --with-debug-symbols
 --debug-manifest-placeholders '[analytics_enabled: "false"]'
 --release-manifest-placeholders '[analytics_enabled: "true"]'

--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@
 
 Wraps Kolibri in an android-compatibility layer. Relies on Python-For-Android to build the APK and for compatibility on the Android platform.
 
+## Installing from Google Play Store
+
+The Kolibri application is available in [Google Play Store][play-store]
+as Endless Key using the app ID `org.endlessos.Key`. When installing the
+app for testing or quality assurance, please use [this
+link][play-store-key-referrer]. This will allow Endless users to be
+filtered out of our analytics.
+
+[play-store]: https://play.google.com/store/apps
+[play-store-key-referrer]: https://play.google.com/store/apps/details?id=org.endlessos.Key&referrer=utm_source%3Deos%26utm_campaign%3Dtest
+
 ## Build on Docker
 
 This project was primarily developed on Docker, so this method is more rigorously tested.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ development environment inside a container.
 
 ## Running the apk from the terminal
 
-1. Run `adb shell am start -n org.learningequality.Kolibri/org.kivy.android.PythonActivity`
+1. Run `adb shell am start -n org.endlessos.Key/org.kivy.android.PythonActivity`
 
 ## Debugging the app
 
@@ -168,7 +168,7 @@ builds without polluting production metrics.
       shorthand for `*:S`, so `adb logcat -s SomeTag` will only show
       logs from `SomeTag`. Alternatively, `*:F` will show only fatal
       logs from other tags.
-  - Uninstall from terminal using `adb shell pm uninstall org.learningequality.Kolibri`. ([Docs](https://developer.android.com/studio/command-line/adb#pm))
+  - Uninstall from terminal using `adb shell pm uninstall org.endlessos.Key`. ([Docs](https://developer.android.com/studio/command-line/adb#pm))
 - Docker shouldn't be rebuilding very often, so it shouldn't be using that much storage. But if it does, you can run `docker system prune` to clear out all "dangling" images, containers, and layers. If you've been constantly rebuilding, it will likely get you several gigabytes of storage.
 
 ## Docker Implementation Notes

--- a/src/kolibri_android/android_utils.py
+++ b/src/kolibri_android/android_utils.py
@@ -12,6 +12,7 @@ from enum import Enum
 from functools import partial
 from pathlib import Path
 from queue import Queue
+from urllib.parse import parse_qsl
 from urllib.parse import urlparse
 
 from android.activity import bind
@@ -23,6 +24,7 @@ from jnius import cast
 from jnius import JavaException
 from jnius import jnius
 
+from .referrer import get_referrer_details
 from .runnable import Runnable
 
 
@@ -836,6 +838,46 @@ def apply_android_workarounds():
     _android11_ext_storage_workarounds()
 
 
+def get_referrer_url(context):
+    """Get Google Play referrer URL
+
+    Retrieves the referrer_url value from shared preferences. If that's
+    not set, the URL is queried from the Play Store and stored.
+    """
+    preferences = get_preferences()
+    url = preferences.getString("referrer_url", None)
+    if url is None:
+        details = get_referrer_details(context)
+        if details is not None:
+            url = details.getInstallReferrer()
+            logger.debug(f"Setting referrer_url='{url}'")
+            editor = get_preferences().edit()
+            editor.putString("referrer_url", url)
+            editor.commit()
+
+    logger.info(f"Installed from referrer URL '{url}'")
+    return url
+
+
+def get_referrer_params(context):
+    """Get Google Play referrer UTM parameters"""
+    # A full Google Play URL looks has the UTM parameters URL encoded
+    # within the referrer query parameter. However, it appears that the
+    # Install Referrer API often (always?) returns only the referrer
+    # value URL decoded. Try to handle both possibilities.
+    url = get_referrer_url(context)
+    url_parts = urlparse(url)
+    if url_parts.scheme:
+        # Full URL. Try to get the referrer query parameter value.
+        url_params = dict(parse_qsl(url_parts.query))
+        referrer = url_params.get("referrer", "")
+    else:
+        # Assume the URL is just the referrer value.
+        referrer = url
+
+    return dict(parse_qsl(referrer))
+
+
 def setup_analytics():
     """Enable or disable Firebase Analytics and Crashlytics
 
@@ -845,6 +887,10 @@ def setup_analytics():
     property. For example, `adb shell setprop
     debug.org.endlessos.key.analytics true`.
     """
+    context = get_activity()
+    referrer = get_referrer_params(context)
+    logger.debug(f"Install referrer parameters: {referrer}")
+
     if BuildConfig.DEBUG:
         logger.debug("Debug build, analytics default disabled")
         analytics_default = False
@@ -871,7 +917,6 @@ def setup_analytics():
         "%s Firebase Analytics and Crashlytics",
         "Enabling" if analytics_enabled else "Disabling",
     )
-    context = get_activity()
     analytics = FirebaseAnalytics.getInstance(context)
     crashlytics = FirebaseCrashlytics.getInstance()
     analytics.setAnalyticsCollectionEnabled(analytics_enabled)

--- a/src/kolibri_android/referrer.py
+++ b/src/kolibri_android/referrer.py
@@ -1,0 +1,93 @@
+import logging
+from contextlib import contextmanager
+from threading import Condition
+
+from jnius import autoclass
+from jnius import java_method
+from jnius import PythonJavaClass
+
+logger = logging.getLogger(__name__)
+
+InstallReferrerClient = autoclass(
+    "com.android.installreferrer.api.InstallReferrerClient"
+)
+InstallReferrerResponse = autoclass(
+    "com.android.installreferrer.api.InstallReferrerClient$InstallReferrerResponse"
+)
+
+
+class ReferrerStateListener(PythonJavaClass):
+    """Implements InstallReferrerStateListener interface from Install Referrer"""
+
+    __javainterfaces__ = [
+        "com/android/installreferrer/api/InstallReferrerStateListener",
+    ]
+    __javacontext__ = "app"
+
+    def __init__(self):
+        super().__init__()
+
+        self._state = None
+        self._ready = Condition()
+
+    def _state_is_available(self):
+        return self._state is not None
+
+    def get_state(self, timeout=5):
+        """Get the current state, blocking for up to timeout seconds"""
+        with self._ready:
+            if not self._ready.wait_for(self._state_is_available, timeout=timeout):
+                logger.warning(
+                    f"Referrer setup did not complete within {timeout} seconds"
+                )
+                return None
+            return self._state
+
+    @java_method("()V")
+    def onInstallReferrerServiceDisconnected(self):
+        with self._ready:
+            logger.info("Install Referrer service disconnected")
+            self._state = InstallReferrerResponse.SERVICE_DISCONNECTED
+            self._ready.notify_all()
+
+    @java_method("(I)V")
+    def onInstallReferrerSetupFinished(self, responseCode):
+        with self._ready:
+            if responseCode == InstallReferrerResponse.OK:
+                logger.info("Install Referrer service connected")
+            else:
+                if responseCode == InstallReferrerResponse.DEVELOPER_ERROR:
+                    reason = "Developer error"
+                elif responseCode == InstallReferrerResponse.FEATURE_NOT_SUPPORTED:
+                    reason = "Feature not supported by Play Store app"
+                elif responseCode == InstallReferrerResponse.SERVICE_DISCONNECTED:
+                    reason = "Play Store service is not connected now"
+                elif responseCode == InstallReferrerResponse.FEATURE_NOT_SUPPORTED:
+                    reason = "Feature not supported by Play Store app"
+                else:
+                    reason = "Unknown"
+                logger.error(f"Install Referrer connection failed: {reason}")
+
+            self._state = responseCode
+            self._ready.notify_all()
+
+
+@contextmanager
+def referrer_client(app_context):
+    """InstallReferrerClient context closing connection upon exit"""
+    client = InstallReferrerClient.newBuilder(app_context).build()
+    try:
+        yield client
+    finally:
+        client.endConnection()
+
+
+def get_referrer_details(context, timeout=5):
+    """Retrieve install referrer details"""
+    with referrer_client(context) as client:
+        listener = ReferrerStateListener()
+        client.startConnection(listener)
+        state = listener.get_state(timeout=timeout)
+        if state != InstallReferrerResponse.OK:
+            return None
+        return client.getInstallReferrer()


### PR DESCRIPTION
Document and gather Google Play Install Referrer data. We want to be able to filter the data on specific campaigns and particularly to filter Endless testers out of our production data. This documents a URL for Endless testers to use when installing Endless Key as well as collecting the Install Referrer data within the app. At the moment the data is just being stored and logged, but later it will also be used to actively disable analytics for Endless testers.

See #128.