### PR TITLE
Disable analytics for Endless testing installs

### DIFF
--- a/src/kolibri_android/android_utils.py
+++ b/src/kolibri_android/android_utils.py
@@ -895,8 +895,18 @@ def setup_analytics():
         logger.debug("Debug build, analytics default disabled")
         analytics_default = False
     else:
-        logger.debug("Release build, analytics default enabled")
-        analytics_default = True
+        # Disable analytics for Endless test installs.
+        if (
+            referrer.get("utm_source", "") == "eos"
+            and referrer.get("utm_campaign", "") == "test"
+        ):
+            logger.debug(
+                "Release build for Endless testing, analytics default disabled"
+            )
+            analytics_default = False
+        else:
+            logger.debug("Release build, analytics default enabled")
+            analytics_default = True
 
     # Allow explicitly enabling or disabling using a system property.
     analytics_enabled = SystemProperties.getBoolean(


### PR DESCRIPTION
If the referrer parameters are `utm_source=eos&utm_campaign=test`, then the installation is from an Endless user following our testing campaign URL. Disable analytics in that case so that our metrics aren't polluted with test behavior.

Fixes #128