### PR TITLE
Configure PythonActivity to open external links in a browser

### DIFF
--- a/src/java/org/learningequality/KolibriAndroidHelper.java
+++ b/src/java/org/learningequality/KolibriAndroidHelper.java
@@ -76,6 +76,8 @@ public class KolibriAndroidHelper {
     public void configure(final Runnable startWithNetwork, final Runnable startWithUSB, final Runnable loadingReady) {
         Log.i(TAG, "KolibriAndroidHelper configure");
 
+        mActivity.mOpenExternalLinksInBrowser = true;
+
         mLoadingWebView.setWebViewClient(new WebViewClient() {
             private boolean mInWelcome = false;
 


### PR DESCRIPTION
A recent change to python-for-android requires that we set the activity's mOpenExternalLinksInBrowser attribute to true.

Closes #133