### PR TITLE
Fix external links to open in browser

### DIFF
--- a/src/kolibri_android/main_activity/activity.py
+++ b/src/kolibri_android/main_activity/activity.py
@@ -100,6 +100,9 @@ class MainActivity(BaseActivity):
     def __init__(self):
         super().__init__()
 
+        # Tell PythonActivity to open external links in a browser.
+        PythonActivity.mOpenExternalLinksInBrowser = True
+
         configure_webview(
             Runnable(self._on_start_with_network),
             Runnable(self._on_start_with_usb),


### PR DESCRIPTION
This is a regression since p4a was upgraded to v2022.09.04 in ab80513. Upstream p4a now requires the `mOpenExternalLinksInBrowser` boolean to be set to `true`.

Fixes #133

This worked in my emulator testing.