### PR TITLE
Jenkins: Change Kolibri WHL URL to v0.16.0-alpha15

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
         // URL for the Kolibri wheel to include.
         // FIXME: It would be nice to cache this somehow.
         // FIXME: Go back to use an official release once that happens on GitHub for 0.16.
-        KOLIBRI_WHL_URL = 'https://github.com/learningequality/kolibri/releases/download/v0.16.0-alpha14/kolibri-0.16.0a14-py2.py3-none-any.whl'
+        KOLIBRI_WHL_URL = 'https://github.com/learningequality/kolibri/releases/download/v0.16.0-alpha15/kolibri-0.16.0a15-py2.py3-none-any.whl'
 
         // Both p4a and gradle cache outputs in the home directory.
         // Point it inside the workspace.


### PR DESCRIPTION
Fixes: https://github.com/endlessm/kolibri-installer-android/issues/146