### PR TITLE
jenkins: Drop RELEASE_NOTES parameter of kolibri-installer-android-upload

### DIFF
--- a/Jenkinsfile-upload
+++ b/Jenkinsfile-upload
@@ -9,6 +9,7 @@ pipeline {
     parameters {
         text(
             name: 'RELEASE_NOTES',
+            default: '[]',
             description: '''\
 <p>Release notes in JSON. The expected format is
 an array of objects with <code>language</code> and <code>text</code>
@@ -19,7 +20,10 @@ properties. For example:</p>
   {"language": "en-US", "text": "Fixed a problem"},
   {"language": "de-DE", "text": "Ein Problem wurde behoben"}
 ]
-</pre>''',
+</pre>
+
+<p>The default value is an empty array, which corresponds to
+no release notes.</p>''',
         )
 }
 


### PR DESCRIPTION
We use kolibri-installer-android-upload job only to upload to internal testers. The real release notes are written in Google Play Console and only when promoting the testing build. For internal testers the notes aren't actually needed.

The parameter recentChangeList of androidApkUpload (Google Play Android Publisher Plugin) [1] is optional. It is passed as the RELEASE_NOTES. Drop RELEASE_NOTES to simplify parameters in Android upload Jenkins.

[1]: https://www.jenkins.io/doc/pipeline/steps/google-play-android-publisher/

https://phabricator.endlessm.com/T34808