### PR TITLE
Fix upload trigger

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,19 +1,14 @@
 // Jenkins pipeline
 // https://www.jenkins.io/doc/book/pipeline/
+//
+// Required parameters: UPLOAD
+
 pipeline {
     agent {
         dockerfile {
             // Try to use the same node to make use of caching.
             reuseNode true
         }
-    }
-
-    parameters {
-        booleanParam(
-            name: 'UPLOAD',
-            defaultValue: false,
-            description: 'Upload the built Kolibri Android packages for internal testers',
-        )
     }
 
     environment {

--- a/Jenkinsfile-promote
+++ b/Jenkinsfile-promote
@@ -1,23 +1,12 @@
 // Jenkins promote pipeline
 //
 // https://www.jenkins.io/doc/book/pipeline/
+//
+// Required parameters: VERSION_CODE, TRACK
 
 pipeline {
     // Any agent is fine as all the work happens on the controller.
     agent any
-
-    parameters {
-        string(
-            name: 'VERSION_CODE',
-            description: 'Version code to promote',
-            trim: true,
-        )
-        choice(
-            name: 'TRACK',
-            description: 'Release track to promote to',
-            choices: ['alpha', 'beta', 'production'],
-        )
-    }
 
     stages {
         stage('Release') {

--- a/Jenkinsfile-upload
+++ b/Jenkinsfile-upload
@@ -1,31 +1,12 @@
 // Jenkins upload pipeline
 //
 // https://www.jenkins.io/doc/book/pipeline/
+//
+// Required parameters: RELEASE_NOTES
 
 pipeline {
     // Any agent is fine as all the work happens in plugins.
     agent any
-
-    parameters {
-        text(
-            name: 'RELEASE_NOTES',
-            defaultValue: '[]',
-            description: '''\
-<p>Release notes in JSON. The expected format is
-an array of objects with <code>language</code> and <code>text</code>
-properties. For example:</p>
-
-<pre>
-[
-  {"language": "en-US", "text": "Fixed a problem"},
-  {"language": "de-DE", "text": "Ein Problem wurde behoben"}
-]
-</pre>
-
-<p>The default value is an empty array, which corresponds to
-no release notes.</p>''',
-        )
-}
 
     stages {
         stage('Copy AAB') {

--- a/Jenkinsfile-upload
+++ b/Jenkinsfile-upload
@@ -16,7 +16,7 @@ pipeline {
                 sh 'rm -rf dist'
                 copyArtifacts(
                     projectName: 'kolibri-installer-android',
-                    selector: lastSuccessful(),
+                    selector: upstream(fallbackToLastSuccessful: true),
                     filter: 'dist/kolibri-release-*.aab, dist/version.json',
                     fingerprintArtifacts: true,
                 )


### PR DESCRIPTION
If the upload job is being triggered by the build job, it will not be
the last successful build yet and `copyArtifacts` will use the AAB from
the previous build. Instead, use the `upstream` selector[1], which uses
the build number of the upstream (triggering) job. Since the upload job
can still be run manually, fallback to the last successful build job.

1. https://plugins.jenkins.io/copyartifact/#plugin-content-pipeline-syntax

https://phabricator.endlessm.com/T34805