### PR TITLE
Fix version number parsing for newer kolibri-explore-plugin versions

### DIFF
--- a/scripts/version.py
+++ b/scripts/version.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import importlib
 import os
 import subprocess
 import sys
@@ -32,6 +33,23 @@ def explore_plugin_version_name():
 
 
 def explore_plugin_version():
+    # kolibri-explore-plugin v6.27.0 and newer store the version in a separate
+    # file, so try that first. Then fall back to parsing __init__.py, which is
+    # what older versions used.
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "_version", f"./{EXPLOREPLUGIN_TARGET}/kolibri_explore_plugin/_version.py"
+        )
+        if not spec:
+            raise ImportError
+
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+        return getattr(module, "__version__")
+    except (ImportError, FileNotFoundError):
+        pass
+
     with open(
         f"./{EXPLOREPLUGIN_TARGET}/kolibri_explore_plugin/__init__.py", "r"
     ) as version_file:

--- a/scripts/version.py
+++ b/scripts/version.py
@@ -59,7 +59,7 @@ def explore_plugin_version():
 
 def explore_plugin_simple_version():
     full_version = explore_plugin_version()
-    major, minor, patch = full_version.split(".")
+    [major, minor, patch, *_] = full_version.split(".")
     if patch == "0":
         return ".".join([major, minor])
     return full_version


### PR DESCRIPTION
How the version number is exported changed in kolibri-explore-plugin 6.27.0, so adapt the APK build code accordingly.

Fixes: https://github.com/endlessm/kolibri-explore-plugin/issues/705