### PR TITLE
Explore version again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,7 @@ p4a_android_distro: needs-android-dirs
 	$(P4A) create $(ARCH_OPTIONS)
 
 .PHONY: needs-version
-needs-version: src/kolibri
+needs-version: src/kolibri local-kolibri-explore-plugin
 	$(eval VERSION_NAME ?= $(shell python3 scripts/version.py version_name))
 	$(eval VERSION_CODE ?= $(shell python3 scripts/version.py version_code))
 	$(eval EK_VERSION ?= $(shell python3 scripts/version.py ek_version))

--- a/Makefile
+++ b/Makefile
@@ -175,6 +175,9 @@ needs-version: src/kolibri local-kolibri-explore-plugin
 	$(eval VERSION_NAME ?= $(shell python3 scripts/version.py version_name))
 	$(eval VERSION_CODE ?= $(shell python3 scripts/version.py version_code))
 	$(eval EK_VERSION ?= $(shell python3 scripts/version.py ek_version))
+	$(if $(VERSION_NAME), ,$(error VERSION_NAME not defined))
+	$(if $(VERSION_CODE), ,$(error VERSION_CODE not defined))
+	$(if $(EK_VERSION), ,$(error EK_VERSION not defined))
 
 dist/version.json: needs-version
 	mkdir -p dist

--- a/scripts/version.py
+++ b/scripts/version.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-import importlib
+import importlib.util
 import os
 import subprocess
 import sys


### PR DESCRIPTION
Really make sure the version identifiers derived from the explore plugin actually work.

Fixes: https://github.com/endlessm/kolibri-explore-plugin/issues/705