### PR TITLE
Pin Cython version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ assets/welcomeScreen/
 src/apps-bundle/
 src/collections/
 src/kolibri/
+src/evil_kolibri/
 whl/
 
 # File format for signing key

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-cython
+cython~=0.29
 virtualenv
 git+https://github.com/endlessm/python-for-android@v2022.09.04-endless10#egg=python-for-android


### PR DESCRIPTION
The brand spanking new 3.0 version of Cython is breaking pyjnius. Pin to the old stable version for now.

Fixes: #164