### PR TITLE
Handle outdated webview package

### DIFF
--- a/.p4a
+++ b/.p4a
@@ -11,6 +11,7 @@
 --allow-minsdk-ndkapi-mismatch
 --permission ACCESS_NETWORK_STATE
 --permission FOREGROUND_SERVICE
+--android-apptheme "@android:style/Theme.Material.Light.NoActionBar"
 --service remoteshell:remoteshell.py
 --presplash assets/presplash.png
 --presplash-color #F15A22

--- a/src/kolibri_android/android_utils.py
+++ b/src/kolibri_android/android_utils.py
@@ -21,8 +21,10 @@ from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 from jnius import autoclass
 from jnius import cast
+from jnius import java_method
 from jnius import JavaException
 from jnius import jnius
+from jnius import PythonJavaClass
 
 from .referrer import get_referrer_details
 from .runnable import Runnable
@@ -31,6 +33,7 @@ from .runnable import Runnable
 logger = logging.getLogger(__name__)
 
 Activity = autoclass("android.app.Activity")
+AlertDialogBuilder = autoclass("android.app.AlertDialog$Builder")
 AndroidString = autoclass("java.lang.String")
 BuildConfig = autoclass("org.endlessos.Key.BuildConfig")
 Context = autoclass("android.content.Context")
@@ -53,6 +56,7 @@ SystemProperties = autoclass("android.os.SystemProperties")
 Timezone = autoclass("java.util.TimeZone")
 Toast = autoclass("android.widget.Toast")
 Uri = autoclass("android.net.Uri")
+WebView = autoclass("android.webkit.WebView")
 FirebaseApp = autoclass("com.google.firebase.FirebaseApp")
 
 ANDROID_VERSION = autoclass("android.os.Build$VERSION")
@@ -71,6 +75,12 @@ ANALYTICS_SYSPROP = "debug.org.endlessos.key.analytics"
 
 
 USB_CONTENT_FLAG_FILENAME = "usb_content_flag"
+
+# Minimum webview major version required
+WEBVIEW_MIN_MAJOR_VERSION = {
+    # Android System Webview
+    "com.google.android.webview": 80,
+}
 
 
 # Globals to keep references to Java objects
@@ -931,6 +941,94 @@ def setup_analytics():
     crashlytics = FirebaseCrashlytics.getInstance()
     analytics.setAnalyticsCollectionEnabled(analytics_enabled)
     crashlytics.setCrashlyticsCollectionEnabled(analytics_enabled)
+
+
+class WebViewUpdateClickListener(PythonJavaClass):
+    """OnClickListener for webview update dialog"""
+
+    __javainterfaces__ = ["android/content/DialogInterface$OnClickListener"]
+    __javacontext__ = "app"
+
+    def __init__(self, activity, package_name):
+        super().__init__()
+        self.activity = activity
+        self.package_name = package_name
+
+    @java_method("(Landroid/content/DialogInterface;I)V")
+    def onClick(self, dialog, which):
+        logger.debug(f"Starting webview update activity for {self.package_name}")
+
+        # Try both the market:// and https://play.google.com/ URIs.
+        uri = Uri.parse(f"market://details?id={self.package_name}")
+        intent = Intent(Intent.ACTION_VIEW, uri)
+        try:
+            self.activity.startActivity(intent)
+        except JavaException as err:
+            if err.classname != "android.content.ActivityNotFoundException":
+                raise
+
+            uri = Uri.parse(
+                f"https://play.google.com/store/apps/details?id={self.package_name}"
+            )
+            intent.setData(uri)
+            try:
+                self.activity.startActivity(intent)
+            except JavaException as err:
+                if err.classname != "android.content.ActivityNotFoundException":
+                    raise
+
+                logger.warning(
+                    f"No activity found to update webview package {self.package_name}"
+                )
+
+
+def check_webview_version():
+    """Check if the current webview meets requirements"""
+    # getCurrentWebViewPackage is only available since API 26.
+    if SDK_INT < 26:
+        logger.warning(f"Cannot get webview package on SDK {SDK_INT}")
+        return
+
+    pkg = WebView.getCurrentWebViewPackage()
+    if pkg is None:
+        logger.warning("Could not determine current webview package")
+        return
+
+    pkg_name = str(pkg.packageName)
+    pkg_version = str(pkg.versionName)
+    logger.info(f'Webview package: {pkg_name} "{pkg_version}"')
+
+    min_major_version = WEBVIEW_MIN_MAJOR_VERSION.get(pkg_name)
+    if min_major_version is None:
+        logger.warning(f"Cannot check webview version for {pkg_name}")
+        return
+
+    try:
+        major_version = int(pkg_version.split(".", 1)[0])
+    except ValueError:
+        logger.warning(f'Could not parse webview major version from "{pkg_version}"')
+        return
+
+    logger.debug(f"{pkg_name} major version: {major_version}")
+    if major_version >= min_major_version:
+        return
+
+    # Create a dialog to instruct the user to update the webview.
+    logger.debug(f"Initiating webview package {pkg_name} update")
+    activity = get_activity()
+    builder = AlertDialogBuilder(activity)
+    builder.setMessage(
+        AndroidString(
+            "You need to update the Android System Webview component to use Endless Key."
+        )
+    )
+    builder.setPositiveButton(
+        AndroidString("Update"), WebViewUpdateClickListener(activity, pkg_name)
+    )
+    builder.setCancelable(False)
+
+    # Show the dialog on the UI thread.
+    Runnable(builder.show)()
 
 
 class StartupState(Enum):

--- a/src/kolibri_android/main_activity/activity.py
+++ b/src/kolibri_android/main_activity/activity.py
@@ -4,6 +4,7 @@ from urllib.parse import urlparse
 
 from jnius import autoclass
 
+from ..android_utils import check_webview_version
 from ..android_utils import choose_endless_key_uris
 from ..android_utils import get_endless_key_uris
 from ..android_utils import has_any_external_storage_device
@@ -169,6 +170,7 @@ class MainActivity(BaseActivity):
             return None
 
     def run(self):
+        check_webview_version()
         show_loading_page(INITIAL_LOADING_PAGE_URL)
         while True:
             if callable(self.TO_RUN_IN_MAIN):


### PR DESCRIPTION
Things will likely go badly if the system webview is outdated since the explore plugin may use newer JS and web resource APIs. Detect that case and prompt the user to update their webview package if possible. While here, change the app theme to use Material instead of the outdated default from pythonforandroid.

Fixes: #160