### PR TITLE
Jenkins: Change Kolibri WHL URL to v0.16.0-beta1

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
         // URL for the Kolibri wheel to include.
         // FIXME: It would be nice to cache this somehow.
         // FIXME: Go back to use an official release once that happens on GitHub for 0.16.
-        KOLIBRI_WHL_URL = 'https://github.com/learningequality/kolibri/releases/download/v0.16.0-alpha18/kolibri-0.16.0a18-py2.py3-none-any.whl'
+        KOLIBRI_WHL_URL = 'https://github.com/learningequality/kolibri/releases/download/v0.16.0-beta1/kolibri-0.16.0b1-py2.py3-none-any.whl'
 
         // Both p4a and gradle cache outputs in the home directory.
         // Point it inside the workspace.


### PR DESCRIPTION
Since kolibri-explore-plugin's PR [Use Kolibri's FileDownloader](https://github.com/endlessm/kolibri-explore-plugin/pull/729) has been merged, the app side can bump Kolibri to v0.16.0-beta0.

Depends on:

- https://github.com/endlessm/kolibri-installer-android/pull/170