### PR TITLE
Dockerfiles: Bump OpenJDK to version 17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         libffi-dev \
         libssl-dev \
         libtool \
-        openjdk-11-jdk-headless \
+        openjdk-17-jdk-headless \
         python-is-python3 \
         python3-dev \
         python3-pip \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,9 @@ FROM docker.io/endlessm/eos:master
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update && \
     apt-get install -y \
+        java-common \
+        ca-certificates-java && \
+    apt-get install -y \
         autoconf \
         automake \
         autopoint \

--- a/Dockerfile-toolbox
+++ b/Dockerfile-toolbox
@@ -15,7 +15,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         libffi-dev \
         libssl-dev \
         libtool \
-        openjdk-11-jdk-headless \
+        openjdk-17-jdk-headless \
         python-is-python3 \
         python3-dev \
         python3-pip \

--- a/Dockerfile-toolbox
+++ b/Dockerfile-toolbox
@@ -6,6 +6,9 @@ FROM docker.io/endlessm/eos-toolbox:master
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update && \
     apt-get install -y \
+        java-common \
+        ca-certificates-java && \
+    apt-get install -y \
         autoconf \
         automake \
         autopoint \


### PR DESCRIPTION
Bump OpenJDK to version 17 for Android SDK (class file version 61.0) compatibility.

Fixes: https://github.com/endlessm/kolibri-installer-android/issues/169