### PR TITLE
Revert "Use Material Light theme"

### DIFF
--- a/.p4a
+++ b/.p4a
@@ -11,7 +11,6 @@
 --allow-minsdk-ndkapi-mismatch
 --permission ACCESS_NETWORK_STATE
 --permission FOREGROUND_SERVICE
---android-apptheme "@android:style/Theme.Material.Light.NoActionBar"
 --service remoteshell:remoteshell.py
 --presplash assets/presplash.png
 --presplash-color #F15A22


### PR DESCRIPTION
This reverts commit 5419378d9f627cebf4c181dc23ceb1044114f2e0.

While this makes the "your webview is too old" dialog ugly, it also
restores the previous titlebar colour on Chrome OS.

This revert should be reverted in future together with a change to set
the titlebar colour.

Fixes https://github.com/endlessm/kolibri-installer-android/issues/172
