### PR TITLE
Material Light theme with black status bar

### DIFF
--- a/.p4a
+++ b/.p4a
@@ -17,6 +17,7 @@
 --icon assets/icon.png
 --icon-fg assets/icon-fg.png
 --icon-bg assets/icon-bg.png
+--window
 --fileprovider-paths src/fileprovider_paths.xml
 --add-asset assets/_load.html:_load.html
 --add-asset assets/welcomeScreen:welcomeScreen

--- a/.p4a
+++ b/.p4a
@@ -11,12 +11,14 @@
 --allow-minsdk-ndkapi-mismatch
 --permission ACCESS_NETWORK_STATE
 --permission FOREGROUND_SERVICE
+--android-apptheme "@style/KeyTheme"
 --service remoteshell:remoteshell.py
 --presplash assets/presplash.png
 --presplash-color #F15A22
 --icon assets/icon.png
 --icon-fg assets/icon-fg.png
 --icon-bg assets/icon-bg.png
+--res-values res/values/styles.xml
 --window
 --fileprovider-paths src/fileprovider_paths.xml
 --add-asset assets/_load.html:_load.html

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 cython~=0.29
 virtualenv
-git+https://github.com/endlessm/python-for-android@v2022.09.04-endless10#egg=python-for-android
+git+https://github.com/endlessm/python-for-android@v2022.09.04-endless11#egg=python-for-android

--- a/res/values/styles.xml
+++ b/res/values/styles.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <style name="KeyTheme" parent="android:Theme.Material.Light.NoActionBar">
+    <item name="android:statusBarColor">@android:color/black</item>
+  </style>
+</resources>


### PR DESCRIPTION
Try again with Material Light but use a custom derived theme that restores the status bar to black. This also uncovers the status bar on pure Android by using a non-Fullscreen theme. That has no effect on ChromeOS but is more reasonable on Android and makes it easier to validate the theme.

This depends on https://github.com/endlessm/python-for-android/pull/19 being merged and released. Marking as a draft until that happens.

Fixes: #174