### PR TITLE
build: Bump to Android API 33

### DIFF
--- a/.p4a
+++ b/.p4a
@@ -6,7 +6,7 @@
 --local-recipes "p4a-recipes"
 --orientation sensor
 --requirements python3,android,pyjnius,genericndkbuild,sqlite3,cryptography,twisted,attrs,bcrypt,service_identity,pyasn1,pyasn1_modules,pyopenssl,openssl,six,liblzma,zstandard,beautifulsoup4==4.10.0,zimply_core,kolibri_explore_plugin~=6.0,kolibri_zim_plugin
---android-api 31
+--android-api 33
 --minsdk 24
 --allow-minsdk-ndkapi-mismatch
 --permission ACCESS_NETWORK_STATE

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,7 @@ clean:
 
 deepclean: clean
 	$(PYTHON_FOR_ANDROID) clean_dists
+	$(PYTHON_FOR_ANDROID) clean_builds
 	rm -r dist || true
 	yes y | $(DOCKER) system prune -a || true
 	rm build_docker 2> /dev/null

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@ else
 	PLATFORM := linux
 endif
 
-ANDROID_API := 31
-ANDROIDNDKVER := 23.2.8568313
+ANDROID_API := 33
+ANDROIDNDKVER := 25.0.8775105
 
 SDK := ${ANDROID_HOME}/android-sdk-$(PLATFORM)
 
@@ -257,8 +257,8 @@ $(SDK)/cmdline-tools/latest/bin/sdkmanager:
 sdk: $(SDK)/cmdline-tools/latest/bin/sdkmanager
 	yes y | $(SDK)/cmdline-tools/latest/bin/sdkmanager "platform-tools"
 	yes y | $(SDK)/cmdline-tools/latest/bin/sdkmanager "platforms;android-$(ANDROID_API)"
-	yes y | $(SDK)/cmdline-tools/latest/bin/sdkmanager "system-images;android-$(ANDROID_API);default;x86_64"
-	yes y | $(SDK)/cmdline-tools/latest/bin/sdkmanager "build-tools;30.0.3"
+	yes y | $(SDK)/cmdline-tools/latest/bin/sdkmanager "system-images;android-$(ANDROID_API);google_apis_playstore;x86_64"
+	yes y | $(SDK)/cmdline-tools/latest/bin/sdkmanager "build-tools;33.0.2"
 	yes y | $(SDK)/cmdline-tools/latest/bin/sdkmanager "ndk;$(ANDROIDNDKVER)"
 	ln -sfT ndk/$(ANDROIDNDKVER) $(SDK)/ndk-bundle
 	@echo "Accepting all licenses"

--- a/README.md
+++ b/README.md
@@ -215,8 +215,8 @@ target will install the necessary pieces. Assuming the SDK is installed in
 Next, install a platform and system image:
 
 ```
-/opt/android/sdk/cmdline-tools/latest/bin/sdkmanager "platforms;android-30"
-/opt/android/sdk/cmdline-tools/latest/bin/sdkmanager "system-images;android-30;default;x86_64"
+/opt/android/sdk/cmdline-tools/latest/bin/sdkmanager "platforms;android-33"
+/opt/android/sdk/cmdline-tools/latest/bin/sdkmanager "system-images;android-33;google_apis_playstore;x86_64"
 ```
 
 Now an [Android Virtual Device
@@ -235,7 +235,7 @@ the system image provided above and a Pixel 5 device:
 
 ```
 /opt/android/sdk/cmdline-tools/latest/bin/avdmanager create avd --name test \
-  --package "system-images;android-30;default;x86_64" --device pixel_5
+  --package "system-images;android-33;google_apis_playstore;x86_64" --device pixel_5
 ```
 
 The AVD should be ready now and `avdmanager list avd` will show the details.


### PR DESCRIPTION
This is needed because Google now require that all apps target an API
level within 1 year of the latest Android release.

The API changes from 31 → 32 and 32 → 33 are minimal and should not
affect our code:
 * https://developer.android.com/sdk/api_diff/32/changes
 * https://developer.android.com/sdk/api_diff/33/changes

It requires a newer version of the NDK and build tools.

Signed-off-by: Philip Withnall <philip@tecnocode.co.uk>

Fixes: https://github.com/endlessm/kolibri-explore-plugin/issues/759