### PR TITLE
Clean even more thoroughly

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,10 +41,12 @@ pipeline {
         stage('Distro') {
             steps {
                 // p4a's cache invalidation has tons of bugs. Clean the
-                // builds and distributions to ensure we get all the
-                // current code copied into it.
+                // builds to ensure we get all the current code copied
+                // into it.
                 sh 'p4a clean builds'
-                sh 'p4a clean dists'
+                // Clean first to ensure we're downloading current
+                // assets.
+                sh 'make clean'
                 sh 'make p4a_android_distro'
             }
         }


### PR DESCRIPTION
A recent Jenkins build included the wrong version of `collections.zip` because the one in the workspace was newer than the requested version. Let's try to fix this for real by making the `make clean` target actually clean everything except for the p4a builds and the downloaded Kolibri wheel file. I checked the results with `git ls-files -o --directory` after a local build and think I got everything.

With that, `make clean` can be run at the beginning of the Jenkins build (in addition to the existing `p4a clean-builds`) and we can be reasonable sure that it will DTRT. The reason not to just wipe the workspace outright is that we want to keep the `_cache` directory for the p4a downloads.

One subtle difference is that the `src/kolibri` target was previously depending on `clean`. Previously that was just cleaning up the `dist` artifacts, but with the more thorough `clean` recipe, that would break everything. Instead, the `dist` targets clean old artifacts as needed.

Fixes: [#806](https://github.com/endlessm/kolibri-explore-plugin/issues/806)