### PR TITLE
WIP: Add endless-key-kolibri-home to build output

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         build-essential \
         ccache \
         git \
+        jq \
         libffi-dev \
         libssl-dev \
         libtool \

--- a/Dockerfile-toolbox
+++ b/Dockerfile-toolbox
@@ -15,6 +15,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         build-essential \
         ccache \
         git \
+        jq \
         libffi-dev \
         libssl-dev \
         libtool \

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ CLEAN_DEPS = \
 	clean-kolibri \
 	clean-apps-bundle \
 	clean-collections \
+	clean-endless-key-kolibri-home \
 	clean-local-kolibri-explore-plugin \
 	clean-loadingScreen
 CLEAN_FILES = \
@@ -145,6 +146,20 @@ clean-apps-bundle:
 src/apps-bundle: clean-apps-bundle apps-bundle.zip
 	unzip -qo apps-bundle.zip -d src/apps-bundle
 
+.PHONY: clean-endless-key-kolibri-home
+clean-endless-key-kolibri-home:
+	- rm -rf src/kolibri/dist/home
+
+# This is phony because we are replacing existing files inside src/kolibri :(
+.PHONY: src/kolibri/dist/home
+src/kolibri/dist/home: export KOLIBRI_HOME = src/kolibri/dist/home
+src/kolibri/dist/home: src/collections src/kolibri
+	rm -rf $@
+	kolibri manage migrate
+	cat src/collections/artist-0001.json | jq '.channels[] | .id' | xargs -n1 kolibri manage importchannel network
+	cat src/collections/artist-0001.json | jq '.channels[] | .id' | xargs -n1 kolibri manage importcontent --manifest=src/collections/artist-0001.json network
+	yes 'yes' | kolibri manage deprovision
+
 .PHONY: collections.zip
 collections.zip:
 	wget -N https://github.com/endlessm/endless-key-collections/releases/latest/download/collections.zip
@@ -193,6 +208,7 @@ DIST_DEPS = \
 	src/kolibri \
 	src/apps-bundle \
 	src/collections \
+	src/kolibri/dist/home \
 	assets/loadingScreen \
 	needs-version \
 	dist/version.json

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 cython~=0.29
 virtualenv
 git+https://github.com/endlessm/python-for-android@v2022.09.04-endless10#egg=python-for-android
+https://github.com/learningequality/kolibri/releases/download/v0.16.0-beta5/kolibri-0.16.0b5-py2.py3-none-any.whl

--- a/src/kolibri_android/kolibri_utils.py
+++ b/src/kolibri_android/kolibri_utils.py
@@ -81,12 +81,17 @@ def _init_kolibri_env():
 
     os.environ["KOLIBRI_CHERRYPY_THREAD_POOL"] = "2"
 
+    os.environ["KOLIBRI_CONTENT_FALLBACK_DIRS"] = SCRIPT_PATH.joinpath(
+        "kolibri", "dist", "home", "content"
+    ).as_posix()
+
     os.environ["KOLIBRI_APPS_BUNDLE_PATH"] = SCRIPT_PATH.joinpath(
         "apps-bundle", "apps"
     ).as_posix()
     os.environ["KOLIBRI_CONTENT_COLLECTIONS_PATH"] = SCRIPT_PATH.joinpath(
         "collections"
     ).as_posix()
+    os.environ["KOLIBRI_HIDE_DISCOVERY_TAB"] = "yes"
 
     node_id = get_android_node_id()
 


### PR DESCRIPTION
The Makefile requires that `kolibri` is installed, and uses it to generate a Kolibri home with content from a provided content manifest.

Helps: https://github.com/endlessm/endless-key-content-private/issues/97

This is an experiment and probably shouldn't be merged.