### PR TITLE
Slim down app

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -477,6 +477,10 @@ project.afterEvaluate {
             pruneTask.configure {
                 inputs.files(requirementsTask)
             }
+            requirementsTask.configure {
+                // Make the requirements task run again if the pruning script has changed.
+                inputs.file("scripts/prunepackages.py")
+            }
             requirementsAssetsTask.configure {
                 // dependsOn is used here instead of wiring the prune task
                 // outputs since there aren't any outputs.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -142,7 +142,10 @@ android {
             signingConfig = signingConfigs.findByName("upload")
             isMinifyEnabled = true
             isShrinkResources = true
-            proguardFiles(getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro")
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro",
+            )
 
             // Enable analytics by default for release builds.
             manifestPlaceholders["analytics_enabled"] = "true"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -90,7 +90,14 @@ android {
         minSdk = 24
 
         ndk {
-            abiFilters += listOf("armeabi-v7a", "arm64-v8a", "x86", "x86_64")
+            // Android ABIs to support. This should be minimized due to the way Chaquopy packages
+            // native Python components. x86_64 is supported because our primary target is
+            // Chromebooks. armeabi-v7a is supported because all other ABIs use it as a secondary
+            // ABI.
+            //
+            // https://developer.android.com/ndk/guides/abis
+            // https://chaquo.com/chaquopy/doc/current/faq.html#faq-size
+            abiFilters += listOf("armeabi-v7a", "x86_64")
         }
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -93,7 +93,7 @@ android {
             // Android ABIs to support. This should be minimized due to the way Chaquopy packages
             // native Python components. x86_64 is supported because our primary target is
             // Chromebooks. armeabi-v7a is supported because all other ABIs use it as a secondary
-            // ABI.
+            // ABI. Keep this in sync with the pruned Kolibri C extension ABIs in prunepackages.py.
             //
             // https://developer.android.com/ndk/guides/abis
             // https://chaquo.com/chaquopy/doc/current/faq.html#faq-size
@@ -191,7 +191,8 @@ android {
 // https://chaquo.com/chaquopy/doc/15.0/android.html
 chaquopy {
     defaultConfig {
-        // Python version
+        // Python version. Keep this in sync with the pruned Kolibri C extension versions in
+        // prunepackages.py.
         version = "3.9"
 
         // Packages to install with pip.

--- a/app/scripts/prunepackages.py
+++ b/app/scripts/prunepackages.py
@@ -17,9 +17,6 @@ REMOVE_LOCALES_DIRS = [
     "common/kolibri/dist/django/contrib/auth/locale",
     "common/kolibri/dist/django/contrib/contenttypes/locale",
     "common/kolibri/dist/django/contrib/flatpages/locale",
-    "common/kolibri/dist/django/contrib/gis/locale",
-    "common/kolibri/dist/django/contrib/humanize/locale",
-    "common/kolibri/dist/django/contrib/postgres/locale",
     "common/kolibri/dist/django/contrib/redirects/locale",
     "common/kolibri/dist/django/contrib/sessions/locale",
     "common/kolibri/dist/django/contrib/sites/locale",
@@ -29,25 +26,47 @@ REMOVE_LOCALES_DIRS = [
 ]
 
 REMOVE_GLOBS = [
+    # Only the Kolibri bundled C extensions for this build are needed. Keep the list of
+    # pruned ABIs and Python versions in sync with build.gradle.kts.
+    "common/kolibri/dist/cext/*/*/armv6l",
+    "common/kolibri/dist/cext/*/*/i686",
+    "common/kolibri/dist/cext/*/*/aarch64",
     "common/kolibri/dist/cext/cp27",
     "common/kolibri/dist/cext/cp36",
     "common/kolibri/dist/cext/cp37",
     "common/kolibri/dist/cext/cp38",
+    # Keep "common/kolibri/dist/cext/cp39" to match Chaquopy Python version 3.9 in
+    # app/build.gradle.kts.
+    "common/kolibri/dist/cext/cp311",
     "common/kolibri/dist/cext/*/Windows",
     # Remove unneeded explore plugin components. JS source files aren't needed since
     # only the webpacked apps in static are used at runtime. The bundled loadingScreen
     # isn't needed as loading-screen.zip is added as an asset.
     "common/kolibri_explore_plugin/assets",
     "common/kolibri_explore_plugin/loadingScreen",
+    # Kolibri doesn't use several large django contrib apps.
+    "common/kolibri/dist/django/contrib/gis",
+    "common/kolibri/dist/django/contrib/humanize",
+    "common/kolibri/dist/django/contrib/postgres",
+    # Tests aren't needed.
+    "common/kolibri/core/*/test",
+    "common/kolibri/utils/tests",
     "common/kolibri/dist/cheroot/test",
-    "common/kolibri/dist/magicbus/test",
     "common/kolibri/dist/colorlog/tests",
     "common/kolibri/dist/django_js_reverse/tests",
+    "common/kolibri/dist/future/backports/test",
+    "common/kolibri/dist/future/moves/test",
     "common/kolibri/dist/future/tests",
     "common/kolibri/dist/ipware/tests",
+    "common/kolibri/dist/importlib_resources/tests",
+    "common/kolibri/dist/json_schema_validator/tests",
+    "common/kolibri/dist/magicbus/test",
     "common/kolibri/dist/more_itertools/tests",
     "common/kolibri/dist/past/tests",
     "common/kolibri/dist/sqlalchemy/testing",
+    "common/kolibri/plugins/*/test",
+    "common/kolibri_explore_plugin/test",
+    # JS map files are only for debugging.
     "**/*.js.map",
     # Chaquopy currently precompiles modules but also keeps the original module
     # for packages specified in extractPackages. We don't want to disable

--- a/app/scripts/prunepackages.py
+++ b/app/scripts/prunepackages.py
@@ -34,6 +34,11 @@ REMOVE_GLOBS = [
     "common/kolibri/dist/cext/cp37",
     "common/kolibri/dist/cext/cp38",
     "common/kolibri/dist/cext/*/Windows",
+    # Remove unneeded explore plugin components. JS source files aren't needed since
+    # only the webpacked apps in static are used at runtime. The bundled loadingScreen
+    # isn't needed as loading-screen.zip is added as an asset.
+    "common/kolibri_explore_plugin/assets",
+    "common/kolibri_explore_plugin/loadingScreen",
     "common/kolibri/dist/cheroot/test",
     "common/kolibri/dist/magicbus/test",
     "common/kolibri/dist/colorlog/tests",


### PR DESCRIPTION
With the switch to chaquopy we've unfortunately exceeded the 150 MB total APK size and Google Play won't accept our AAB bundle. The biggest offender is chaquopy due to the way it [packages native Python components](https://chaquo.com/chaquopy/doc/current/faq.html#faq-size). These changes get the size under 150 MB in my local testing and seem to have no adverse affects on the app from my minimal testing.

The most controversial change is limiting the ABIs, but I can't get it under the limit without it. Really this should only mildly affect arm64 devices, though.

Fixes: #185