### PR TITLE
Add version code back to version name

### DIFF
--- a/app/scripts/versions.py
+++ b/app/scripts/versions.py
@@ -81,13 +81,14 @@ def git_tag():
     return p.communicate()[0].rstrip()
 
 
-def get_version_name(pkgdir):
+def get_version_name(pkgdir, version_code):
     """
     Returns the user-visible version to be used for the Android app.
     """
-    return "{} {}".format(
+    return "{} {}{}".format(
         explore_plugin_version_name(pkgdir),
         explore_plugin_simple_version(pkgdir),
+        f"-{version_code}" if version_code else "",
     )
 
 
@@ -103,8 +104,8 @@ def get_ek_version(pkgdir):
     )
 
 
-def get_version_data(pkgdir):
-    version_name = get_version_name(pkgdir)
+def get_version_data(pkgdir, version_code):
+    version_name = get_version_name(pkgdir, version_code)
     ek_version = get_ek_version(pkgdir)
     return {
         "versionName": version_name,
@@ -133,7 +134,7 @@ if __name__ == "__main__":
     )
     args = ap.parse_args()
 
-    data = get_version_data(args.pkgdir)
+    data = get_version_data(args.pkgdir, args.version_code)
     if args.version_code:
         data["versionCode"] = args.version_code
     if args.output:


### PR DESCRIPTION
This was lost in 0b0edae2729a21372fc4be5c3cb2e25a979ca62f when moving the version handling script to use as a Gradle task. Initially it didn't have access to the version code, so I just dropped that from the version name. However, later I allowed passing the version code as an option to simplify generation of the version JSON file. Since the version code may be available, restore the `-$version_code` suffix in the version name if possible.