### PR TITLE
Update collections to 0.4.1

### DIFF
--- a/app/gradle.properties
+++ b/app/gradle.properties
@@ -31,5 +31,5 @@ zimUrl=
 
 # endless-key-collections version or collections.zip URL. The URL is
 # preferred if both are set.
-collectionsVersion=0.3.1
+collectionsVersion=0.4.1
 collectionsUrl=


### PR DESCRIPTION
At least 0.4.0 is required for kolibri-explore-plugin 7.9.0 since it will try to download the spanish-extras pack.