### PR TITLE
Update to Android API 34

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ else
 endif
 
 ANDROID_HOME ?= $(HOME)/.android/sdk
-ANDROID_API := 33
+ANDROID_API := 34
 
 ADB := adb
 DOCKER := docker

--- a/README.md
+++ b/README.md
@@ -212,8 +212,8 @@ target will install the necessary pieces. Assuming the SDK is installed in
 Next, install a platform and system image:
 
 ```
-/opt/android/sdk/cmdline-tools/latest/bin/sdkmanager "platforms;android-33"
-/opt/android/sdk/cmdline-tools/latest/bin/sdkmanager "system-images;android-33;google_apis_playstore;x86_64"
+/opt/android/sdk/cmdline-tools/latest/bin/sdkmanager "platforms;android-34"
+/opt/android/sdk/cmdline-tools/latest/bin/sdkmanager "system-images;android-34;google_apis_playstore;x86_64"
 ```
 
 Now an [Android Virtual Device
@@ -232,7 +232,7 @@ the system image provided above and a Pixel 5 device:
 
 ```
 /opt/android/sdk/cmdline-tools/latest/bin/avdmanager create avd --name test \
-  --package "system-images;android-33;google_apis_playstore;x86_64" --device pixel_5
+  --package "system-images;android-34;google_apis_playstore;x86_64" --device pixel_5
 ```
 
 The AVD should be ready now and `avdmanager list avd` will show the details.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -79,14 +79,14 @@ android {
     // Main Java namespace
     namespace = "org.endlessos.key"
 
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         // App ID. Customarily this is lowercase and matches the Java
         // namespace, but we've already published with Key uppercased.
         applicationId = "org.endlessos.Key"
 
-        targetSdk = 33
+        targetSdk = 34
         minSdk = 24
 
         ndk {
@@ -176,13 +176,13 @@ android {
         // https://developer.android.com/reference/tools/gradle-api/8.1/com/android/build/api/dsl/ManagedVirtualDevice
         managedDevices {
             devices {
-                maybeCreate<ManagedVirtualDevice>("desktop33").apply {
+                maybeCreate<ManagedVirtualDevice>("desktop34").apply {
                     // Use device profiles you typically see in Android Studio. See avdmanager list
                     // device.
                     device = "Medium Desktop"
                     // Google automated test device. Use aosp-atd to test without Google APIs.
                     systemImageSource = "google-atd"
-                    apiLevel = 33
+                    apiLevel = 34
                 }
             }
         }


### PR DESCRIPTION
Google Play requires updating to API 34 prior to August 31, 2024 in order to publish updates[1]. While we don't intend to publish updates any time soon, this does help keep the app installable for the next Android version while requiring no changes to the app.

1. https://support.google.com/googleplay/android-developer/answer/11926878

https://phabricator.endlessm.com/T35551